### PR TITLE
Add info on threading

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,10 @@ Some additional functions that are also available:
 * `fdiv(x,y)`: divide (`x ./ y` in Base)
 * `sincos(x)`: returns `(sin(x), cos(x))`
 
+## Setting the number of threads
+
+Accelerate is multithreaded by default. You can set an upper limit on the number of threads through the `VECLIB_MAXIMUM_THREADS` environment variable; for example, for single-threaded execution, start Julia as `VECLIB_MAXIMUM_THREADS=1 julia`. Accelerate does not support the `BLAS.set_num_threads(nthreads)` and `BLAS.get_num_threads()` API used by other BLAS backends (`set_num_threads` is a no-op and `get_num_threads` returns a hardcoded default).
+
 ## Example
 
 To use the Accelerate BLAS and LAPACK, simply load the library:


### PR DESCRIPTION
Thought it was worth putting this information in the readme. Perhaps @staticfloat can confirm that the wording is correct?

I can't find any official documentation on the `VECLIB_MAXIMUM_THREADS` variable (this search comes up dry: https://developer.apple.com/search/?q=VECLIB_MAXIMUM_THREADS&type=Documentation), but it's all over the forums, and I can confirm that it works.

Btw. is there a technical reason why `BLAS.{set,get}_num_threads` isn't hooked up to Accelerate's API for this? (See https://developer.apple.com/documentation/accelerate/blas?language=objc#4434515) (EDIT: I mean apart from the fact that you can only select single vs multiple threads rather than set an exact number)