### PR TITLE
libSparse direct solving methods and matrix arithmetic

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,6 +5,7 @@ version = "0.4.1"
 [deps]
 Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
 [compat]
 julia = "1.9"

--- a/src/AppleAccelerate.jl
+++ b/src/AppleAccelerate.jl
@@ -95,6 +95,11 @@ if Sys.isapple()
     include("Util.jl")
     include("Array.jl")
     include("DSP.jl")
+    include("libSparse/wrappers.jl")
+    include("libSparse/AASparseMatrices.jl")
+    include("libSparse/AAFactorizations.jl")
+    export AASparseMatrix, muladd!
+    export AAFactorization, solve, solve!, factor!
 end
 
 end # module

--- a/src/libSparse/AAFactorizations.jl
+++ b/src/libSparse/AAFactorizations.jl
@@ -1,0 +1,89 @@
+@doc """Factorization object.
+
+Create via `f = AAFactorization(A::SparseMatrixCSC{T, Int64})`. Calls to `solve`,
+`ldiv`, and their in-place versions require explicitly passing in the
+factorization object as the first argument. On construction, the struct stores a
+placeholder yet-to-be-factored object: the factorization is computed upon the first call
+to `solve`, or by explicitly calling `factor!`. If the matrix is symmetric, it defaults to
+a Cholesky factorization; otherwise, it defaults to QR.
+"""
+mutable struct AAFactorization{T<:vTypes} <: LinearAlgebra.Factorization{T}
+    matrixObj::AASparseMatrix{T}
+    _factorization::SparseOpaqueFactorization{T}
+end
+
+# returns an AAFactorization containing A and a dummy "yet-to-be-factored" factorization.
+function AAFactorization(A::AASparseMatrix{T}) where T<:vTypes
+    obj = AAFactorization(A, SparseOpaqueFactorization(T))
+    function cleanup(aa_fact)
+        # If it's yet-to-be-factored, then there's nothing to release
+        if !(aa_fact._factorization.status in (SparseYetToBeFactored,
+                                                            SparseStatusReleased))
+            SparseCleanup(aa_fact._factorization)
+        end
+    end
+    return finalizer(cleanup, obj)
+end
+
+LinearAlgebra.factorize(A::AASparseMatrix{T}) where T<:vTypes = AAFactorization(A)
+
+# julia's LinearAlgebra module doesn't provide similar constructors.
+AAFactorization(M::SparseMatrixCSC{T, Int64}) where T<:vTypes =
+                                        AAFactorization(AASparseMatrix(M))
+
+# easiest way to make this follow the defaults and naming conventions of LinearAlgebra?
+# TODO: add tests for the different kinds of factorizations, beyond QR.
+function factor!(aa_fact::AAFactorization{T},
+            kind::SparseFactorization_t = SparseFactorizationTBD) where T<:vTypes
+    if aa_fact._factorization.status == SparseYetToBeFactored
+        if kind == SparseFactorizationTBD
+            # so far I'm only dealing with ordinary and symmetric
+            kind = issymmetric(aa_fact.matrixObj) ? SparseFactorizationCholesky :
+                            SparseFactorizationQR
+        end
+        aa_fact._factorization = SparseFactor(kind, aa_fact.matrixObj.matrix)
+        if aa_fact._factorization.status == SparseMatrixIsSingular
+            # throw a SingularException? Factoring a singular matrix usually does not
+            # make it this far: the call to SparseFactor throws an error.
+            throw(ErrorException("The matrix is singular."))
+        elseif aa_fact._factorization.status == SparseStatusFailed
+            throw(ErrorException("Factorization failed: check that the matrix"
+                        * " has the correct properties for the factorization."))
+        elseif aa_fact._factorization.status != SparseStatusOk
+            throw(ErrorException("Something went wrong internally. Error type: "
+                                * String(aa_fact._factorization.status)))
+        end
+    end
+end
+
+function solve(aa_fact::AAFactorization{T}, b::StridedVecOrMat{T}) where T<:vTypes
+    @assert size(aa_fact.matrixObj)[2] == size(b, 1)
+    factor!(aa_fact)
+    x = Array{T}(undef, size(aa_fact.matrixObj)[2], size(b)[2:end]...)
+    SparseSolve(aa_fact._factorization, b, x)
+    return x
+end
+
+function solve!(aa_fact::AAFactorization{T}, xb::StridedVecOrMat{T}) where T<:vTypes
+    @assert (xb isa StridedVector) ||
+            (size(aa_fact.matrixObj)[1] == size(aa_fact.matrixObj)[2]) "Can't in-place " *
+            "solve: x and b are different sizes and Julia cannot resize a matrix."
+    factor!(aa_fact)
+    SparseSolve(aa_fact._factorization, xb)
+    return xb # written in imitation of KLU.jl, which also returns
+end
+
+LinearAlgebra.ldiv!(aa_fact::AAFactorization{T}, xb::StridedVecOrMat{T}) where T<:vTypes =
+        solve!(aa_fact, xb)
+
+function LinearAlgebra.ldiv!(x::StridedVecOrMat{T},
+                            aa_fact::AAFactorization{T},
+                            b::StridedVecOrMat{T}) where T<:vTypes
+    @assert size(aa_fact.matrixObj)[2] == size(b, 1)
+    factor!(aa_fact)
+    SparseSolve(aa_fact._factorization, b, x)
+    return x
+end
+
+
+

--- a/src/libSparse/AASparseMatrices.jl
+++ b/src/libSparse/AASparseMatrices.jl
@@ -1,0 +1,116 @@
+
+@doc """Matrix wrapper, containing the Apple sparse matrix struct
+and the pointed-to data. Construct from a `SparseMatrixCSC`.
+
+Multiplication (`*`) and multiply-add (`muladd!`) with both
+`Vector` and `Matrix` objects are working.
+`transpose` creates a new matrix structure with the opposite
+transpose flag, that references the same CSC data.
+"""
+mutable struct AASparseMatrix{T<:vTypes} <: AbstractMatrix{T}
+    matrix::SparseMatrix{T}
+    _colptr::Vector{Clong}
+    _rowval::Vector{Cint}
+    _nzval::Vector{T}
+end
+
+# I use StridedVector here because it allows for views/references,
+# so you can do shallow copies: same pointed-to data. Better way?
+"""Constructor for advanced usage: col and row here are 0-indexed CSC data.
+Could allow for shared  `_colptr`, `_rowval`, `_nzval` between multiple
+structs via views or references. Currently unused."""
+function AASparseMatrix(n::Int, m::Int,
+            col::StridedVector{Clong}, row::StridedVector{Cint},
+            data::StridedVector{T},
+            attributes::att_type = ATT_ORDINARY) where T<:vTypes
+    @assert stride(col, 1) == 1 && stride(row, 1) == 1 && stride(data, 1) == 1
+    # I'm assuming here that pointer(row) == pointer(_row_inds),
+    # ie that col, row, and data are passed by reference, not by value.
+    s = SparseMatrixStructure(n, m, pointer(col),
+                    pointer(row), attributes, 1)
+    m = SparseMatrix(s, pointer(data))
+    return AASparseMatrix(m, col, row, data)
+end
+
+function AASparseMatrix(sparseM::SparseMatrixCSC{T, Int64},
+                        attributes::att_type = ATT_ORDINARY) where T<:vTypes
+    if issymmetric(sparseM) && attributes == ATT_ORDINARY
+        return AASparseMatrix(tril(sparseM), ATT_SYMMETRIC | ATT_LOWER_TRIANGLE)
+    elseif (istril(sparseM) || istriu(sparseM)) && attributes == ATT_ORDINARY
+        attributes = istril(sparseM) ? ATT_TRI_LOWER : ATT_TRI_UPPER
+    end
+    if attributes in (ATT_TRI_LOWER, ATT_TRI_UPPER) &&
+                    all(diag(sparseM) .== one(eltype(sparseM)))
+        attributes |= ATT_UNIT_TRIANGULAR
+    end
+    c = Clong.(sparseM.colptr .+ -1)
+    r = Cint.(sparseM.rowval .+ -1)
+    vals = copy(sparseM.nzval)
+    return AASparseMatrix(size(sparseM)..., c, r, vals, attributes)
+end
+
+Base.size(M::AASparseMatrix) = (M.matrix.structure.rowCount,
+                                    M.matrix.structure.columnCount)
+Base.eltype(M::AASparseMatrix) = eltype(M._nzval)
+LinearAlgebra.issymmetric(M::AASparseMatrix) = (M.matrix.structure.attributes &
+                                                ATT_KIND_MASK) == ATT_SYMMETRIC
+istri(M::AASparseMatrix) = (M.matrix.structure.attributes
+                                    & ATT_KIND_MASK) == ATT_TRIANGULAR
+LinearAlgebra.istriu(M::AASparseMatrix) = istri(M) && (MM.matrix.structure.attributes
+                                        & ATT_TRIANGLE_MASK == ATT_LOWER_TRIANGLE)
+LinearAlgebra.istril(M::AASparseMatrix) = istri(M) && (MM.matrix.structure.attributes
+                                        & ATT_TRIANGLE_MASK == ATT_UPPER_TRIANGLE)
+
+function Base.getindex(M::AASparseMatrix, i::Int, j::Int)
+    @assert all((1, 1) .<= (i,j) .<= size(M))
+    (startCol, endCol) = (M._colptr[j], M._colptr[j+1]-1) .+ 1
+    rowsInCol = @view M._rowval[startCol:endCol]
+    ind = searchsortedfirst(rowsInCol, i-1)
+    if ind <= length(rowsInCol) && rowsInCol[ind] == i-1
+        return M._nzval[startCol+ind-1]
+    end
+    return zero(eltype(M))
+end
+
+function Base.getindex(M::AASparseMatrix, i::Int)
+    @assert 1 <= i <= size(M)[1]*size(M)[2]
+    return M[(i-1) % size(M)[1] + 1, div(i-1, size(M)[1]) + 1]
+end
+# Creates a new structure, referring to the same data,
+# but with the transpose flag (in attributes) flipped.
+# TODO: untested
+Base.transpose(M::AASparseMatrix) = AASparseMatrix(SparseGetTranspose(M.matrix),
+                        M._colptr, M._rowval, M._nzval)
+
+function Base.:(*)(A::AASparseMatrix{T}, x::StridedVecOrMat{T}) where T<:vTypes
+    @assert size(x)[1] == size(A)[2]
+    y = Array{T}(undef, size(A)[1], size(x)[2:end]...)
+    SparseMultiply(A.matrix, x, y)
+    return y
+end
+
+function Base.:(*)(alpha::T, A::AASparseMatrix{T},
+                            x::StridedVecOrMat{T}) where T<:vTypes
+    @assert size(x)[1] == size(A)[2]
+    y = Array{T}(undef, size(A)[1], size(x)[2:end]...)
+    SparseMultiply(alpha, A.matrix, x, y)
+    return y
+end
+
+"""
+Computes y += A*x in place. Note that this modifies its LAST argument.
+"""
+function muladd!(A::AASparseMatrix{T}, x::StridedVecOrMat{T},
+                    y::StridedVecOrMat{T}) where T<:vTypes
+    @assert size(x) == size(y) && size(x)[1] == size(A)[2]
+    SparseMultiplyAdd(A.matrix, x, y)
+end
+
+"""
+Computes y += alpha*A*x in place. Note that this modifies its LAST argument.
+"""
+function muladd!(alpha::T, A::AASparseMatrix{T},
+                x::StridedVecOrMat{T}, y::StridedVecOrMat{T}) where T<:vTypes
+    @assert size(x) == size(y) && size(x)[1] == size(A)[2]
+    SparseMultiplyAdd(alpha, A.matrix, x, y)
+end

--- a/src/libSparse/wrappers.jl
+++ b/src/libSparse/wrappers.jl
@@ -1,0 +1,444 @@
+using SparseArrays
+using Libdl
+
+# header found at: /Library/Developer/CommandLineTools/SDKs/MacOSX15.sdk/System/
+# Library/Frameworks/Accelerate.framework/Versions/A/Frameworks/vecLib.framework/
+# Versions/A/Headers/Sparse/Solve.h (replace MacOSX15 with correct version number)
+
+# unused. But if I can find a library that supports C-style structs
+# of packed bitflags with enum fields, then I'll want them.
+#=
+@enum SparseTriangle_t::UInt8 begin
+    SparseUpperTriangle = 0
+    SparseLowerTriangle = 1
+end
+
+@enum SparseKind_t::UInt32 begin
+    SparseOrdinary = 0
+    SparseTriangular = 1
+    SparseUnitTriangular = 2
+    SparseSymmetric = 3
+end=#
+
+@enum SparseFactorization_t::UInt8 begin
+    SparseFactorizationCholesky = 0
+    SparseFactorizationLDLT = 1
+    SparseFactorizationLDLTUnpivoted = 2
+    SparseFactorizationLDLTSBK = 3
+    SparseFactorizationLDLTTPP = 4
+    SparseFactorizationQR = 40
+    SparseFactorizationCholeskyAtA = 41
+    SparseFactorizationTBD = 64 # my own addition.
+end
+
+@enum SparseOrder_t::UInt8 begin
+    SparseOrderDefault = 0
+    SparseOrderUser = 1
+    SparseOrderAMD = 2
+    SparseOrderMetis = 3
+    SparseOrderCOLAMD = 4
+end
+
+@enum SparseScaling_t::UInt8 begin
+    SpraseScalingDefault = 0
+    SparseScalingUser = 1
+    SparseScalingQuilibriationInf = 2
+end
+
+@enum SparseStatus_t::Int32 begin
+    SparseStatusOk = 0
+    SparseStatusFailed = -1
+    SparseMatrixIsSingular = -2
+    SparseInternalError = -3
+    SparseParameterError = -4
+    SparseYetToBeFactored = -5 # my own addition.
+    SparseStatusReleased = -2147483647
+end
+
+@enum SparseControl_t::UInt32 begin
+    SparseDefaultControl = 0
+end
+
+# can't implement SparseAttributes directly. Workaround:
+const att_type = Cuint
+const ATT_TRANSPOSE = att_type(1)
+const ATT_UPPER_TRIANGLE = att_type(0)
+const ATT_LOWER_TRIANGLE = att_type(2)
+const ATT_ORDINARY = att_type(0)
+const ATT_TRIANGULAR = att_type(4)
+const ATT_UNIT_TRIANGULAR = att_type(8)
+const ATT_SYMMETRIC = att_type(12)
+const ATT_ALLOCATED_BY_SPARSE = att_type(1) << 15
+const ATT_TRI_LOWER = ATT_TRIANGULAR | ATT_LOWER_TRIANGLE
+const ATT_TRI_UPPER = ATT_TRIANGULAR | ATT_UPPER_TRIANGLE
+const ATT_KIND_MASK = att_type(12)
+const ATT_TRIANGLE_MASK = att_type(4)
+
+const vTypes = Union{Cfloat, Cdouble}
+
+struct SparseMatrixStructure
+    rowCount::Cint
+    columnCount::Cint
+    columnStarts::Ptr{Clong} # Apple uses different types for indices
+    rowIndices::Ptr{Cint} # whereas SparseMatrixCSC uses the same
+    attributes::att_type
+    blockSize::UInt8
+end
+
+struct SparseNumericFactorOptions
+    control::SparseControl_t
+    scalingMethod::SparseScaling_t
+    scaling::Ptr{Cvoid}
+    pivotTolerance::Float64
+    zeroTolerance::Float64
+end
+
+# default tolerance parameters found in SolveImplementation.h header.
+SparseNumericFactorOptions(T::Type) = SparseNumericFactorOptions(
+    SparseDefaultControl,
+    SpraseScalingDefault,
+    C_NULL,
+    T == Cfloat ? 0.1 : 0.01,
+    eps(T)*1e-4
+)
+
+# Note: to use system defaults, values of malloc/free should be
+# nil, which is *not the same* as C_NULL.
+struct SparseSymbolicFactorOptions
+    control::SparseControl_t
+    orderMethod::SparseOrder_t
+    order::Ptr{Cvoid}
+    ignoreRowsAndColumns::Ptr{Cvoid}
+    malloc::Ptr{Cvoid} # arg: Csize_t
+    free::Ptr{Cvoid} # arg: Ptr{Cvoid}
+    reportError::Ptr{Cvoid} # arg: Cstring, assuming null-terminated.
+end
+
+SparseSymbolicFactorOptions() = SparseSymbolicFactorOptions(
+    SparseDefaultControl,
+    SparseOrderDefault,
+    C_NULL,
+    C_NULL,
+    @cfunction(Libc.malloc, Ptr{Cvoid}, (Csize_t,)),
+    @cfunction(Libc.free, Cvoid, (Ptr{Cvoid},)),
+    @cfunction(text->error(unsafe_string(text)), Cvoid, (Cstring, ))
+)
+
+struct DenseVector{T<:vTypes}
+    count::Cint
+    data::Ptr{T}
+end
+
+struct SparseMatrix{T<:vTypes}
+    structure::SparseMatrixStructure
+    data::Ptr{T}
+end
+
+struct DenseMatrix{T<:vTypes}
+    rowCount::Cint
+    columnCount::Cint
+    columnStride::Cint
+    attributes::att_type
+    data::Ptr{T}
+end
+
+struct SparseOpaqueSymbolicFactorization
+    status::SparseStatus_t 
+    rowCount::Cint 
+    columnCount::Cint
+    attributes::att_type
+    blockSize::UInt8
+    type::SparseFactorization_t
+    factorization::Ptr{Cvoid}
+    workspaceSize_Float::Csize_t
+    workspaceSize_Double::Csize_t
+    factorSize_Float::Csize_t
+    factorSize_Double::Csize_t
+end
+
+SparseOpaqueSymbolicFactorization() = SparseOpaqueSymbolicFactorization(
+    SparseYetToBeFactored,
+    0, 0,
+    ATT_ORDINARY,
+    0,
+    SparseFactorizationQR,
+    C_NULL,
+    0, 0, 0, 0
+)
+
+# T isn't used in struct body, but I need it for type dispatch.
+# The header has _Double, _Float variants (with identical bodies).
+struct SparseOpaqueFactorization{T<:vTypes}
+    status::SparseStatus_t
+    attributes::att_type
+    symbolicFactorization::SparseOpaqueSymbolicFactorization
+    userFactorStorage::Bool
+    numericFactorization::Ptr{Cvoid}
+    solveWorkspaceRequiredStatic::Csize_t
+    solveWorkspaceRequiredPerRHS::Csize_t
+end
+
+# placeholder object, for type stability reasons
+SparseOpaqueFactorization(T::Type) = SparseOpaqueFactorization{T}(
+    SparseYetToBeFactored,
+    ATT_ORDINARY,
+    SparseOpaqueSymbolicFactorization(),
+    false,
+    C_NULL,
+    0, 0
+)
+
+# note: I haven't implemented anything involving Subfactor, Preconditioner, or IterativeMethod
+const LIBSPARSE = "/System/Library/Frameworks/Accelerate.framework/Versions/A/Frameworks/"*
+                    "vecLib.framework/libSparse.dylib"
+
+Base.cconvert(::Type{DenseMatrix{T}}, m::StridedMatrix{T}) where T<:vTypes = m
+
+function Base.unsafe_convert(::Type{DenseMatrix{T}}, m::StridedMatrix{T}) where T<:vTypes
+    @assert stride(m, 1) == 1
+    # hard-coded ATT_ORDINARY
+    return DenseMatrix{T}(size(m)..., stride(m, 2), ATT_ORDINARY, pointer(m))
+end
+
+Base.cconvert(::Type{DenseVector{T}}, v::StridedVector{T}) where T<:vTypes = v
+
+function Base.unsafe_convert(::Type{DenseVector{T}}, v::StridedVector{T}) where T<:vTypes
+    @assert stride(v, 1) == 1
+    return DenseVector{T}(size(v)[1], pointer(v))
+end
+
+for T in (Cfloat, Cdouble)
+    # write a macro to make this less copy-paste heavy? Most of the function
+    # bodies are straight @ccalls, replacing Strided with Dense, but a few aren't.
+
+    # also may want to add guardrails in case the mangled function names
+    # change at some later date.
+
+    # see https://discourse.julialang.org/t/apple-accelerate-sparse-solvers/110175
+    local dmMultMangled = T == Cfloat ? :_Z14SparseMultiply18SparseMatrix_Float17DenseMatrix_FloatS0_ :
+                        :_Z14SparseMultiply19SparseMatrix_Double18DenseMatrix_DoubleS0_
+    @eval begin
+        function SparseMultiply(arg1::SparseMatrix{$T}, arg2::StridedMatrix{$T},
+                                                            arg3::StridedMatrix{$T})
+            @ccall LIBSPARSE.$dmMultMangled(arg1::SparseMatrix{$T}, arg2::DenseMatrix{$T},
+                                                arg3::DenseMatrix{$T})::Cvoid
+        end
+    end
+
+    local dvMultMangled = T == Cfloat ? :_Z14SparseMultiply18SparseMatrix_Float17DenseVector_FloatS0_ :
+                        :_Z14SparseMultiply19SparseMatrix_Double18DenseVector_DoubleS0_
+    @eval begin
+        function SparseMultiply(arg1::SparseMatrix{$T}, arg2::StridedVector{$T},
+                                                        arg3::StridedVector{$T})
+            @ccall LIBSPARSE.$dvMultMangled(arg1::SparseMatrix{$T}, arg2::DenseVector{$T},
+                                            arg3::DenseVector{$T})::Cvoid
+        end
+    end
+
+    local sdmMultMangled = T == Cfloat ? :_Z14SparseMultiplyf18SparseMatrix_Float17DenseMatrix_FloatS0_ :
+                                :_Z14SparseMultiplyd19SparseMatrix_Double18DenseMatrix_DoubleS0_
+    @eval begin
+        function SparseMultiply(arg1::$T, arg2::SparseMatrix{$T}, arg3::StridedMatrix{$T},
+                                                    arg4::StridedMatrix{$T})
+            @ccall LIBSPARSE.$sdmMultMangled(arg1::$T, arg2::SparseMatrix{$T},
+                                                arg3::DenseMatrix{$T}, arg4::DenseMatrix{$T})::Cvoid
+        end
+    end
+
+    local sdvMultMangled = T == Cfloat ? :_Z14SparseMultiplyf18SparseMatrix_Float17DenseVector_FloatS0_ :
+                                        :_Z14SparseMultiplyd19SparseMatrix_Double18DenseVector_DoubleS0_
+    @eval SparseMultiply(arg1::$T,
+                        arg2::SparseMatrix{$T},
+                        arg3::StridedVector{$T},
+                        arg4::StridedVector{$T}) = @ccall (
+            LIBSPARSE.$sdvMultMangled(arg1::$T,
+                                    arg2::SparseMatrix{$T},
+                                    arg3::DenseVector{$T},
+                                    arg4::DenseVector{$T})::Cvoid
+        )
+
+    local dmMultAddMangled = T == Cfloat ? :_Z17SparseMultiplyAdd18SparseMatrix_Float17DenseMatrix_FloatS0_ :
+                                            :_Z17SparseMultiplyAdd19SparseMatrix_Double18DenseMatrix_DoubleS0_
+    @eval SparseMultiplyAdd(arg1::SparseMatrix{$T},
+                            arg2::StridedMatrix{$T},
+                            arg3::StridedMatrix{$T}) = @ccall (
+            LIBSPARSE.$dmMultAddMangled(arg1::SparseMatrix{$T},
+                                        arg2::DenseMatrix{$T},
+                                        arg3::DenseMatrix{$T})::Cvoid
+        )
+
+    local dvMultAddMangled = T == Cfloat ? :_Z17SparseMultiplyAdd18SparseMatrix_Float17DenseVector_FloatS0_ :
+                                            :_Z17SparseMultiplyAdd19SparseMatrix_Double18DenseVector_DoubleS0_
+    @eval SparseMultiplyAdd(arg1::SparseMatrix{$T},
+                            arg2::StridedVector{$T},
+                            arg3::StridedVector{$T}) = @ccall(
+            LIBSPARSE.$dvMultAddMangled(arg1::SparseMatrix{$T},
+                                        arg2::DenseVector{$T},
+                                        arg3::DenseVector{$T})::Cvoid
+        )
+
+    local sdmMultAddMangled = T == Cfloat ? :_Z17SparseMultiplyAddf18SparseMatrix_Float17DenseMatrix_FloatS0_ :
+                                        :_Z17SparseMultiplyAddd19SparseMatrix_Double18DenseMatrix_DoubleS0_
+    @eval SparseMultiplyAdd(arg0::$T,
+                            arg1::SparseMatrix{$T},
+                            arg2::StridedMatrix{$T},
+                            arg3::StridedMatrix{$T}) = @ccall (
+            LIBSPARSE.$sdmMultAddMangled(arg0::$T,
+                                        arg1::SparseMatrix{$T},
+                                        arg2::DenseMatrix{$T},
+                                        arg3::DenseMatrix{$T})::Cvoid
+        )
+
+    local sdvMultAddMangled = T == Cfloat ? :_Z17SparseMultiplyAddf18SparseMatrix_Float17DenseVector_FloatS0_ :
+                                        :_Z17SparseMultiplyAddd19SparseMatrix_Double18DenseVector_DoubleS0_
+    @eval SparseMultiplyAdd(arg0::$T,
+                            arg1::SparseMatrix{$T},
+                            arg2::StridedVector{$T},
+                            arg3::StridedVector{$T}) = @ccall (
+            LIBSPARSE.$sdvMultAddMangled(arg0::$T,
+                                        arg1::SparseMatrix{$T},
+                                        arg2::DenseVector{$T},
+                                        arg3::DenseVector{$T})::Cvoid
+        )
+
+    local mTransposeMangled = T == Cfloat ? :_Z18SparseGetTranspose18SparseMatrix_Float :
+                                            :_Z18SparseGetTranspose19SparseMatrix_Double
+    @eval SparseGetTranspose(arg1::SparseMatrix{$T}) = @ccall(
+        LIBSPARSE.$mTransposeMangled(arg1::SparseMatrix{$T})::SparseMatrix{$T}
+    )
+    # skipped: 2 subfactor transposes.
+    local ofTransposeMangled = T == Cfloat ? :_Z18SparseGetTranspose31SparseOpaqueFactorization_Float :
+                                        :_Z18SparseGetTranspose32SparseOpaqueFactorization_Double
+    @eval SparseGetTranspose(arg1::SparseOpaqueFactorization{$T}) = @ccall (
+            LIBSPARSE.$ofTransposeMangled(arg1::SparseOpaqueFactorization{$T})::SparseOpaqueFactorization{$T}
+    )
+
+    # TODO: these SparseConvertFromCoord functions are unused and untested.
+    local convertCoordMangled = T == Cfloat ? :_Z27SparseConvertFromCoordinateiilh18SparseAttributes_tPKiS1_PKf :
+                                            :_Z27SparseConvertFromCoordinateiilh18SparseAttributes_tPKiS1_PKd
+    @eval begin
+        function SparseConvertFromCoord(arg1::Cint, arg2::Cint, arg3::Clong, arg4::Cuchar, arg5::$att_type,
+                                        arg6::Ptr{Cint}, arg7::Ptr{Cint}, arg8::Ptr{$T})
+            @ccall LIBSPARSE.$convertCoordMangled(arg1::Cint, arg2::Cint, arg3::Clong, arg4::Cuchar, arg5::$att_type,
+                                                    arg6::Ptr{Cint}, arg7::Ptr{Cint}, arg8::Ptr{$T})::SparseMatrix{$T}
+        end
+    end
+
+    local uConvertCoordMangled = T == Cfloat ? :_Z27SparseConvertFromCoordinateiilh18SparseAttributes_tPKiS1_PKdPvS4_ :
+                                            :_Z27SparseConvertFromCoordinateiilh18SparseAttributes_tPKiS1_PKfPvS4_
+    @eval begin
+        function SparseConvertFromCoord(arg1::Cint, arg2::Cint, arg3::Clong, arg4::Cuchar, arg5::$att_type,
+                    arg6::Ptr{Cint}, arg7::Ptr{Cint}, arg8::Ptr{$T}, arg9::Ptr{Cvoid}, arg10::Ptr{Cvoid})
+            @ccall LIBSPARSE.$uConvertCoordMangled(arg1::Cint, arg2::Cint, arg3::Clong, arg4::Cuchar, arg5::$att_type,
+                    arg6::Ptr{Cint}, arg7::Ptr{Cint}, arg8::Ptr{$T}, arg9::Ptr{Cvoid}, arg10::Ptr{Cvoid})::SparseMatrix{$T}
+        end
+    end
+
+    local mCleanup = T == Cfloat ? :_Z13SparseCleanup18SparseMatrix_Float :
+                                     :_Z13SparseCleanup19SparseMatrix_Double
+    @eval SparseCleanup(arg1::SparseMatrix{$T}) = @ccall (
+            LIBSPARSE.$mCleanup(arg1::SparseMatrix{$T})::Cvoid
+    )
+    
+    local ofCleanup = T == Cfloat ? :_Z13SparseCleanup31SparseOpaqueFactorization_Float :
+                                    :_Z13SparseCleanup32SparseOpaqueFactorization_Double
+    @eval SparseCleanup(arg1::SparseOpaqueFactorization{$T}) = @ccall (
+            LIBSPARSE.$ofCleanup(arg1::SparseOpaqueFactorization{$T})::Cvoid
+    )
+
+    @eval SparseFactor(arg1::SparseFactorization_t,
+                        arg2::SparseMatrix{$T},
+                        noErrors::Bool = false) = 
+                noErrors ? SparseFactor(arg1, arg2) :
+                SparseFactor(arg1, arg2, SparseSymbolicFactorOptions(), SparseNumericFactorOptions($T)) 
+
+    local sparseFactorMatrix = T == Cfloat ? :_Z12SparseFactorh18SparseMatrix_Float :
+                                                :_Z12SparseFactorh19SparseMatrix_Double
+    @eval function SparseFactorNoErrors(arg1::SparseFactorization_t,
+                                arg2::SparseMatrix{$T})::SparseOpaqueFactorization{$T}
+        @assert arg1 != SparseFactorizationTBD
+        @ccall(LIBSPARSE.$sparseFactorMatrix(arg1::Cuint,
+                                        arg2::SparseMatrix{$T})::SparseOpaqueFactorization{$T})
+    end
+
+    local sparseFactorMatrixOpts = T == Cfloat ? :_Z12SparseFactorh18SparseMatrix_Float27SparseSymbolicFactorOptions26SparseNumericFactorOptions :
+                                           :_Z12SparseFactorh19SparseMatrix_Double27SparseSymbolicFactorOptions26SparseNumericFactorOptions     
+    @eval function SparseFactor(arg1::SparseFactorization_t,
+                    arg2::SparseMatrix{$T},
+                    arg3::SparseSymbolicFactorOptions,
+                    arg4::SparseNumericFactorOptions)
+        @assert arg1 != SparseFactorizationTBD
+        @ccall(LIBSPARSE.$sparseFactorMatrixOpts(
+                    arg1::Cuint,
+                    arg2::SparseMatrix{$T},
+                    arg3::SparseSymbolicFactorOptions,
+                    arg4::SparseNumericFactorOptions
+            )::SparseOpaqueFactorization{$T}
+        )
+    end
+
+    local sparseSolveInplace = T == Cfloat ? :_Z11SparseSolve31SparseOpaqueFactorization_Float17DenseMatrix_Float :
+                                            :_Z11SparseSolve32SparseOpaqueFactorization_Double18DenseMatrix_Double
+    @eval function SparseSolve(arg1::SparseOpaqueFactorization{$T},
+                            arg2::StridedMatrix{$T})
+        @ccall LIBSPARSE.$sparseSolveInplace(arg1::SparseOpaqueFactorization{$T},
+                                                arg2::DenseMatrix{$T})::Cvoid
+    end
+
+    local sparseSolve = T == Cfloat ? :_Z11SparseSolve31SparseOpaqueFactorization_Float17DenseMatrix_FloatS0_ :
+                                :_Z11SparseSolve32SparseOpaqueFactorization_Double18DenseMatrix_DoubleS0_
+    @eval SparseSolve(arg1::SparseOpaqueFactorization{$T}, arg2::StridedMatrix{$T},
+                        arg3::StridedMatrix{$T}) = @ccall (
+        LIBSPARSE.$sparseSolve(arg1::SparseOpaqueFactorization{$T}, arg2::DenseMatrix{$T}, 
+                                    arg3::DenseMatrix{$T})::Cvoid
+    )
+
+    local sparseSolveVecInPlace = T == Cfloat ? :_Z11SparseSolve31SparseOpaqueFactorization_Float17DenseVector_Float :
+                                :_Z11SparseSolve32SparseOpaqueFactorization_Double18DenseVector_Double
+    @eval function SparseSolve(arg1::SparseOpaqueFactorization{$T},
+                                arg2::StridedVector{$T})
+        @ccall LIBSPARSE.$sparseSolveVecInPlace(arg1::SparseOpaqueFactorization{$T},
+                                            arg2::DenseVector{$T})::Cvoid
+        resize!(arg2, arg1.symbolicFactorization.columnCount)
+    end
+
+    local sparseSolveVec = T == Cfloat ? :_Z11SparseSolve31SparseOpaqueFactorization_Float17DenseVector_FloatS0_ :
+                                    :_Z11SparseSolve32SparseOpaqueFactorization_Double18DenseVector_DoubleS0_
+    @eval SparseSolve(arg1::SparseOpaqueFactorization{$T},
+                    arg2::StridedVector{$T},
+                    arg3::StridedVector{$T}) = @ccall (
+        LIBSPARSE.$sparseSolveVec(arg1::SparseOpaqueFactorization{$T},
+                                arg2::DenseVector{$T},
+                                arg3::DenseVector{$T})::Cvoid
+    )
+end
+
+SparseCleanup(arg1::SparseOpaqueSymbolicFactorization) = @ccall (
+        LIBSPARSE._Z13SparseCleanup33SparseOpaqueSymbolicFactorization(
+                                arg1::SparseOpaqueSymbolicFactorization)::Cvoid
+)
+
+function SparseFactor(arg1::SparseFactorization_t,
+        arg2::SparseMatrixStructure,
+        noErrors::Bool = false)
+    noErrors ? SparseFactorNoErrors(arg1, arg2) :
+            SparseFactor(arg1, arg2, SparseSymbolicFactorOptions())
+end
+
+# keep just in case libSparse's default malloc/free cooperate better
+# with the library code (due to being from Objective-C, not from C)
+SparseFactorNoErrors(arg1::SparseFactorization_t, arg2::SparseMatrixStructure) = @ccall (
+    LIBSPARSE._Z12SparseFactorh21SparseMatrixStructure(
+        arg1::Cuint, arg2::SparseMatrixStructure
+    )::SparseOpaqueSymbolicFactorization
+)
+
+SparseFactor(arg1::SparseFactorization_t,
+            arg2::SparseMatrixStructure,
+            arg3::SparseSymbolicFactorOptions) = @ccall(
+     LIBSPARSE._Z12SparseFactorh21SparseMatrixStructure27SparseSymbolicFactorOptions(
+                arg1::Cuint,
+                arg2::SparseMatrixStructure,
+                arg3::SparseSymbolicFactorOptions
+    )::SparseOpaqueSymbolicFactorization
+)

--- a/test/libSparseTests.jl
+++ b/test/libSparseTests.jl
@@ -1,0 +1,290 @@
+using AppleAccelerate
+using SparseArrays
+using LinearAlgebra
+@testset "libSparse" begin
+    @testset "wrappers" begin
+        @testset "SparseMultiply and SparseMultiplyAdd" begin
+            # less copy-paste heavy way via meta programming features?
+            for T in (Float32, Float64)
+                @eval begin
+                    dense = rand($T, 3,3)
+                    denseV = rand($T, 3)
+                    dense2 = zeros($T, 3,3)
+                    denseV2 = zeros($T, 3)
+                    sparseM = sprand($T, 3, 3, 0.5)
+                    sparse_data = sparseM.nzval
+                    col_inds =  Clong.(sparseM.colptr .+ -1)
+                    row_inds = Cint.(sparseM.rowval .+ -1)
+                    GC.@preserve col_inds row_inds sparse_data begin
+                        s = AppleAccelerate.SparseMatrixStructure(3, 3,
+                            pointer(col_inds), pointer(row_inds),
+                            AppleAccelerate.ATT_ORDINARY, 1
+                        )
+                        sparse_matrix = AppleAccelerate.SparseMatrix{$T}(s, pointer(sparse_data))
+                        AppleAccelerate.SparseMultiply(sparse_matrix, dense, dense2)
+                        @test dense2 ≈ sparseM * dense
+                        AppleAccelerate.SparseMultiply(sparse_matrix, denseV, denseV2)
+                        @test denseV2 ≈ sparseM * denseV
+                        scalar = rand($T)
+                        AppleAccelerate.SparseMultiply(scalar, sparse_matrix, dense, dense2)
+                        @test dense2 ≈ scalar * sparseM * dense
+                        AppleAccelerate.SparseMultiply(scalar, sparse_matrix, denseV, denseV2)
+                        @test denseV2 ≈ scalar * sparseM * denseV
+                        fill!(dense2, 1.0)
+                        fill!(denseV2, 1.0)
+                        AppleAccelerate.SparseMultiplyAdd(sparse_matrix, dense, dense2)
+                        @test dense2≈ ones(size(dense2))+sparseM * dense
+                        AppleAccelerate.SparseMultiplyAdd(sparse_matrix, denseV, denseV2)
+                        @test denseV2 ≈ ones(size(denseV2))+sparseM * denseV
+                        fill!(dense2, 1.0)
+                        fill!(denseV2, 1.0)
+                        scalar = rand($T)
+                        AppleAccelerate.SparseMultiplyAdd(scalar, sparse_matrix, dense, dense2)
+                        @test dense2 ≈ ones(size(dense2))+ scalar * sparseM * dense
+                        AppleAccelerate.SparseMultiplyAdd(scalar, sparse_matrix, denseV, denseV2)
+                        @test denseV2 ≈ ones(size(denseV2))+ scalar * sparseM * denseV
+                    end
+                end
+            end
+        end
+        @testset "cconvert and unsafe_convert dense" begin
+            dense = rand(3,3)
+            denseV = rand(3)
+            dense2 = zeros(3, 3)
+            denseV2 = zeros(3)
+            sparseM = sprand(3, 3, 0.5)
+            sparse_data = sparseM.nzval
+            col_inds =  Clong.(sparseM.colptr .+ -1)
+            row_inds = Cint.(sparseM.rowval .+ -1)
+            # for lack of a way to call cconvert directly, I'll use the matrix multiply routines.
+            GC.@preserve sparse_data col_inds row_inds begin
+                s = AppleAccelerate.SparseMatrixStructure(3, 3,
+                        pointer(col_inds), pointer(row_inds),
+                        AppleAccelerate.ATT_ORDINARY, 1)
+                sparse_matrix = AppleAccelerate.SparseMatrix{Cdouble}(s, pointer(sparse_data))
+                AppleAccelerate.SparseMultiply(sparse_matrix, dense, dense2)
+                @test dense2 ≈ sparseM * dense
+                AppleAccelerate.SparseMultiply(sparse_matrix, denseV, denseV2)
+                @test denseV2 ≈ sparseM * denseV
+            end
+        end
+        @testset "transpose" begin 
+            for T in (Float32, Float64)
+                @eval begin
+                    sparseM = sprand($T, 3, 4, 0.5)
+                    sparse_data = sparseM.nzval
+                    col_inds =  Clong.(sparseM.colptr .+ -1)
+                    row_inds = Cint.(sparseM.rowval .+ -1)
+                    GC.@preserve sparse_data col_inds row_inds begin
+                        s = AppleAccelerate.SparseMatrixStructure(3, 4,
+                                pointer(col_inds), pointer(row_inds),
+                                AppleAccelerate.ATT_ORDINARY, 1)
+                        sparse_matrix = AppleAccelerate.SparseMatrix{$T}(s,
+                                                pointer(sparse_data))
+                        ATT_TRANSP = AppleAccelerate.ATT_TRANSPOSE
+                        res = AppleAccelerate.SparseGetTranspose(sparse_matrix)
+                        @test res.data == sparse_matrix.data &&
+                                    (res.structure.attributes & ATT_TRANSP != zero(typeof(ATT_TRANSP)))
+                        original = AppleAccelerate.SparseGetTranspose(res)
+                        @test original.data == sparse_matrix.data &&
+                                (original.structure.attributes & ATT_TRANSP == zero(typeof(ATT_TRANSP)))
+                    end
+                end
+            end
+        end
+        @testset "SparseFactor" begin
+            for T in (Float32, Float64)
+                @eval begin
+                    sparseM = sprand($T, 4, 4, 0.5)
+                    while det(sparseM) == 0
+                        global sparseM = sprand($T, 4, 4, 0.5)
+                    end
+                    sparse_data = copy(sparseM.nzval)
+                    col_inds = Clong.(sparseM.colptr .+ -1)
+                    row_inds = Cint.(sparseM.rowval .+ -1)
+                    expected = rand($T, 4, 4)
+                    B = Array(sparseM) * expected
+                    GC.@preserve sparse_data col_inds row_inds begin
+                        s = AppleAccelerate.SparseMatrixStructure(4, 4,
+                            pointer(col_inds), pointer(row_inds),
+                            AppleAccelerate.ATT_ORDINARY, 1)
+                        sparse_matrix = AppleAccelerate.SparseMatrix{$T}(s,
+                                                pointer(sparse_data))
+                        qrType = AppleAccelerate.SparseFactorizationQR
+                        sf = AppleAccelerate.SparseFactor(qrType, s)
+                        @test sf.status == AppleAccelerate.SparseStatusOk
+                        f = AppleAccelerate.SparseFactor(qrType, sparse_matrix)
+                        AppleAccelerate.SparseSolve(f, B)
+                        @test B ≈ expected
+                        AppleAccelerate.SparseCleanup(f)
+                        AppleAccelerate.SparseCleanup(sf)
+                    end
+                end
+            end
+        end
+    end
+    @testset "AASparseMatrix" begin
+        @testset "arithmetic" begin
+            N = 10
+            sparseM = sprand(N, N, 0.3)
+            alpha = rand(Float64)
+            aaM = AASparseMatrix(sparseM)
+            X, x = rand(N, N), rand(N)
+            @test aaM*x ≈ sparseM*x
+            @test aaM*X ≈ sparseM*X
+            @test alpha*aaM*x ≈ alpha*sparseM*x
+            @test alpha*aaM*X ≈ alpha*sparseM*X
+            Y, y = rand(N,N), rand(N)
+            FMA, fma = sparseM*X + Y, sparseM*x + y
+            muladd!(aaM, x, y)
+            muladd!(aaM, X, Y)
+            @test Y ≈ FMA
+            @test y ≈ fma
+            Y, y = rand(N,N), rand(N)
+            FMA2, fma2 = alpha*sparseM*X + Y, alpha*sparseM*x + y
+            muladd!(alpha, aaM, x, y)
+            muladd!(alpha, aaM, X, Y)
+            @test Y ≈ FMA2
+            @test y ≈ fma2
+        end
+        @testset "getindex" begin
+            N = 3
+            M = 4
+            sparseM = sprand(N, M, 0.5)
+            aaM = AASparseMatrix(sparseM)
+            @test size(aaM) == size(sparseM)
+            for i in 1:N
+                for j in 1:M
+                    @test aaM[i,j] == sparseM[i,j]
+                end
+            end
+            denseM = Array(sparseM)
+            for i in 1:(N*M)
+                @test denseM[i] == aaM[i]
+            end
+        end
+        @testset "special matrices" begin
+            N = 3
+            sparseM = sprand(N, N, 0.5)
+            while istriu(sparseM) || istril(sparseM)
+                sparseM = sprand(N, N, 0.5)
+            end
+            ordinary = AASparseMatrix(sparseM)
+            @test !issymmetric(ordinary) && !istril(ordinary) && !istriu(ordinary)
+            symmetricM = sparse(sparseM + sparseM')
+            @assert issymmetric(symmetricM) && !istril(symmetricM) && !istriu(symmetricM)
+            symmetric = AASparseMatrix(symmetricM)
+            @test issymmetric(symmetric) && !istril(symmetric) && !istriu(symmetric)
+            upper_tri, lower_tri = sparse(I, N, N), sparse(I, N, N)
+            upper_tri[1, 3] = 1.0
+            lower_tri[3, 1] = 1.0
+            @test !issymmetric(upper_tri) && !istril(upper_tri) && istriu(upper_tri)
+            @test !issymmetric(lower_tri) && istril(lower_tri) && !istriu(lower_tri)
+        end
+    end
+
+    @testset "AAFactorization" begin
+        @testset "QR factor/solve/ldiv" begin
+            for T in (Float32, Float64)
+                @eval begin
+                    N = 3
+                    jlA = sprand($T, N, N, 0.5)
+                    while det(jlA) ≈ 0
+                        global jlA = sprand($T, N, N, 0.5)
+                    end
+                    test_fact = AAFactorization(jlA)
+                    B = rand($T, N, N)
+                    if issymmetric(jlA)
+                        jlA[1,2] += 0.1
+                    end
+                    @test solve(test_fact, B) ≈ Array(jlA) \ B
+                    b = rand($T, N)
+                    @test solve(test_fact, b) ≈ Array(jlA) \ b
+                    @test test_fact \ B ≈ Array(jlA) \ B
+                    @test test_fact \ b ≈ Array(jlA) \ b
+                end
+            end
+        end
+        @testset "Error handling" begin
+            N = 5
+            err1 = nothing
+            singular = spzeros(Float64, N, N)
+            singular[1, 2] = 1.0
+            try
+                f = AAFactorization(singular)
+                factor!(f)
+            catch err1
+            end
+            @test sprint(showerror, err1) == "Matrix is structurally singular\n"
+            
+            err2 = nothing
+            temp = sprand(N, N, 0.5)
+            # add big negative value to lower-right corner of positive definite.
+            nonPosDef = sparse(temp*temp' + diagm(rand(N)) +
+                            diagm(vcat(zeros(Float64, N-1), [-1*float(N+1)])))
+            try
+                f = AAFactorization(nonPosDef)
+                factor!(f, AppleAccelerate.SparseFactorizationCholesky)
+            catch err2
+            end
+            @test err2 !== nothing
+        
+            err3 = nothing
+            nonSymmetric = sparse(temp*temp' + diagm(rand(N)) + singular)
+            try
+                f = AAFactorization(nonSymmetric)
+                @assert size(f.matrixObj)[1] == size(f.matrixObj)[2]
+                factor!(f, AppleAccelerate.SparseFactorizationCholesky)
+            catch err3
+            end
+            # they say "non-square:" I think they really mean "non-symmetric."
+            @test sprint(showerror, err3) == "Cannot perform symmetric" *
+                    " matrix factorization of non-square matrix.\n"
+        end
+
+        @testset "Cholesky" begin
+            # create a random symmetric positive-definite matrix A.
+            N = 4
+            temp = sprand(N, N, 0.3)
+            A = sparse(temp*temp' + diagm(rand(N)))
+            sym_fact = AAFactorization(A)
+            factor!(sym_fact)
+            x, X = rand(N), rand(N, 4)
+            b, B = A*x, A*X
+            @test solve(sym_fact, b) ≈ x
+            @test solve(sym_fact, B) ≈ X
+        end
+
+        @testset "non-square in-place solve" begin
+            # using high density to avoid structurally singular matrices.
+            tallMatrix = sprand(6,3,0.9)
+            aa_fact = AAFactorization(tallMatrix)
+            x, X = rand(3), rand(3, 3)
+            b, B = tallMatrix * x, tallMatrix * X
+            @test isapprox(solve!(aa_fact, b), x; 0.001)
+            # solve!(aa_fact, B)
+            # @test isapprox(B, X; 0.001)
+            shortMatrix = sprand(3,4,0.9)
+            aa_fact2 = AAFactorization(shortMatrix)
+            x, X = rand(4), rand(4,4)
+            b, B = shortMatrix * x, shortMatrix * X
+            bx, BX = zeros(4), zeros(4,4)
+            bx[1:3], BX[1:3, :] = b, B
+            # Seems like julia and apple make different choices
+            # when there's multiple solutions. which is odd because I thought
+            # they both did the minimal norm solution...
+            # @test isapprox(solve!(aa_fact2, copy(bx)), shortMatrix\b)
+            @test isapprox(shortMatrix * solve!(aa_fact2, bx), b)
+            
+            # solve!(aa_fact2, BX)
+            # @test BX ≈ X
+        end 
+    end
+    @testset "factorize" begin
+        jlM = sprand(4,4, .9)
+        aaM = AASparseMatrix(jlM)
+        f = factorize(aaM)
+        b = rand(4)
+        @test f \ b ≈ jlM \ b
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,6 +7,8 @@ if !Sys.isapple()
     exit(0)
 end
 
+include("libSparseTests.jl")
+
 Random.seed!(7)
 N = 1_000
 
@@ -405,4 +407,3 @@ end
     run(`$(Base.julia_cmd()) --project=$(Base.active_project()) $(dir)/runtests.jl LinearAlgebra/blas LinearAlgebra/lapack`)
 end;
 end
-


### PR DESCRIPTION
`libSparse/wrappers.jl` contains wrappers for the classes in `libSparse`, calling the Objective-C functions with `@ccall` as if they're C. This has its challenges--e.g. Julia doesn't recognize Objective-C's `os_log_error`--but so far, I've been able to work around them.  I matched up the mangled and de-mangled functions via a [dyld extractor](https://github.com/keith/dyld-shared-cache-extractor) and llvm-cxxfilt, as suggested [on Discourse](https://discourse.julialang.org/t/apple-accelerate-sparse-solvers/110175/7).

The `AASparseMatrix{T}` struct is a wrapper for Apple's `SparseMatrix_{Float/Double}`. I've implemented the supported matrix arithmetic operations the `AASparseMatrix` class: `*` for Apple's `SparseMultiply` and `muladd!` for Apple's `SparseMultiplyAdd`.

Likewise, `AAFactorization{T}` is a wrapper for Apple's `SparseOpaqueFactorization_{Float/Double}`. Unlike Julia, you need to explicitly construct the factorization object, and provide it the first argument to `solve` (or `ldiv!`). You can do things like
```
using SparseArrays, AppleAccelerate
N = 10
jlM = sprand(N, N, .4)
aaM = AASparseMatrix(jlM)
f = AAFactorization(aaM) 
b = rand(N)
@assert f \ b ≈ jlM \ b # this will error if jlM is singular.
```

Places where this could use some work:
1. My way of attaching a Julia function to each C function is very copy-paste heavy. Writing a macro is probably a better way to go, but a bit beyond my skills at this point.
2. I'm hard-coding in the mangled names. Those very well could change at some point in the future: add guardrails so that it's an informative error if things do break. Or better yet, automate the de-mangling.
3. Bring the interface of `AAFactorization` more in line with Julia's `LinearAlgebra`.
4. Expand functionality, beyond direct methods and Cholesky/QR factorizations.