### PR TITLE
Add SIMDMath: scalar math that vectorises inside @simd loops

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -18,7 +18,7 @@ Random = "1"
 SparseArrays = "1"
 Statistics = "1"
 Test = "1"
-julia = "1.10"
+julia = "1.11"
 
 [extras]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"

--- a/Project.toml
+++ b/Project.toml
@@ -11,6 +11,7 @@ SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 Aqua = "0.8"
 DSP = "0.8.4"
 FFTW = "1.10"
+InteractiveUtils = "1"
 Libdl = "1"
 LinearAlgebra = "1"
 Random = "1"
@@ -23,10 +24,11 @@ julia = "1.10"
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 DSP = "717857b8-e6f2-59f4-9121-6e50c889abd2"
 FFTW = "7a1cc6ca-52ef-59f5-83cd-3a7055c09341"
+InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Aqua", "DSP", "FFTW", "Random", "SparseArrays", "Statistics", "Test"]
+test = ["Aqua", "DSP", "FFTW", "InteractiveUtils", "Random", "SparseArrays", "Statistics", "Test"]

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
   <a href="https://JuliaLinearAlgebra.github.io/AppleAccelerate.jl/dev/"><img src="https://img.shields.io/badge/docs-dev-blue.svg" alt="Docs"/></a>
   <a href="https://juliahub.com/ui/Packages/General/AppleAccelerate"><img src="https://juliahub.com/docs/General/AppleAccelerate/stable/version.svg" alt="JuliaHub"/></a>
   <a href="https://opensource.org/licenses/MIT"><img src="https://img.shields.io/badge/License-MIT-yellow.svg" alt="License: MIT"/></a>
-  <a href="https://julialang.org/downloads/"><img src="https://img.shields.io/badge/Julia-≥1.10-blue.svg" alt="Julia compat"/></a>
+  <a href="https://julialang.org/downloads/"><img src="https://img.shields.io/badge/Julia-≥1.11-blue.svg" alt="Julia compat"/></a>
 </p>
 
 A Julia interface to Apple's [Accelerate framework](https://developer.apple.com/documentation/accelerate), providing:
@@ -20,7 +20,7 @@ A Julia interface to Apple's [Accelerate framework](https://developer.apple.com/
 
 ## Installation
 
-Requires macOS 13.4+ and Julia 1.10+.
+Requires macOS 13.4+ and Julia 1.11+.
 
 ```julia
 using Pkg

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ A Julia interface to Apple's [Accelerate framework](https://developer.apple.com/
 - **Dense linear algebra** via BLAS/LAPACK forwarding through [libblastrampoline](https://github.com/JuliaLinearAlgebra/libblastrampoline) — all standard `LinearAlgebra` operations (`lu`, `qr`, `svd`, `cholesky`, `eigen`, etc.) are accelerated transparently — **6–14× faster** GEMM than OpenBLAS on Apple Silicon, **2–4× faster** factorizations and solves
 - **Sparse linear algebra** via `libSparse` — sparse matrix operations and direct solvers (QR, Cholesky, LDLT) — **faster for Float32 QR** and **Cholesky at N=5000** vs SuiteSparse
 - **Signal Processing** — FFT, DCT, convolution, cross-correlation, biquad filtering, window functions — **on par with FFTW** for complex FFT, **up to 2× faster** for Float32 real FFT
+- **SIMD math inside `@simd` loops** via `AppleAccelerate.SIMDMath` — scalar math functions that LLVM turns into SIMD calls, for loops the array API can't express (strided access, values computed on the fly) — **2–4× faster** than a scalar Base loop
 
 ## Installation
 
@@ -44,6 +45,17 @@ Y = AppleAccelerate.sin(X)
 # FFT
 x = randn(ComplexF64, 1024)
 X = AppleAccelerate.fft(x)
+
+# SIMD math inside a loop the array API above can't express.
+# Prefer AppleAccelerate.exp/log on whole arrays when you can -- they're faster.
+using AppleAccelerate.SIMDMath: log
+function logsum_strided(X, stride)
+    u = zero(eltype(X))
+    @simd for i in 1:stride:length(X)
+        @inbounds u += log(X[i])
+    end
+    u
+end
 ```
 
 ## Documentation

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -7,6 +7,7 @@ makedocs(;
     pages = [
         "Introduction" => "index.md",
         "Array Operations" => "array.md",
+        "SIMD Math in `@simd` Loops" => "simdmath.md",
         "Dense Linear Algebra" => "blas.md",
         "Sparse Linear Algebra" => "sparse.md",
         "FFT & Transforms" => "fft.md",

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -4,7 +4,7 @@ A Julia interface to Apple's [Accelerate framework](https://developer.apple.com/
 
 ## Installation
 
-Requires macOS 13.4+ and Julia 1.10+.
+Requires macOS 13.4+ and Julia 1.11+.
 
 ```julia
 using Pkg

--- a/docs/src/simdmath.md
+++ b/docs/src/simdmath.md
@@ -75,19 +75,65 @@ All are defined for `Float32` and `Float64` only.
 
 | | |
 |---|---|
-| One argument | `acos`, `acosh`, `asin`, `asinh`, `atan`, `atanh`, `cbrt`, `cos`, `cosh`, `cospi`, `erf`, `erfc`, `exp`, `exp10`, `exp2`, `expm1`, `log`, `log10`, `log1p`, `log2`, `sin`, `sinh`, `sinpi`, `tan`, `tanh`, `tanpi`, `tgamma` |
+| One argument | `acos`, `acosh`, `asin`, `asinh`, `atan`, `atanh`, `cbrt`, `cos`, `cosh`, `cospi`, `exp`, `exp10`, `exp2`, `expm1`, `log`, `log10`, `log1p`, `log2`, `sin`, `sinh`, `sinpi`, `tan`, `tanh`, `tanpi` |
 | Two arguments | `atan(y, x)`, `hypot`, `nextafter`, `pow`, `rem`, `remainder` |
 
-`erf`, `erfc`, `tgamma`, `nextafter`, `pow` and `remainder` have no `Base`
-counterpart with matching semantics, so they are named after their C equivalents.
-Use `pow(x, y)` rather than `x^y`.
+`nextafter`, `pow` and `remainder` have no `Base` counterpart with matching
+semantics, so they are named after their C equivalents. Use `pow(x, y)` rather than
+`x^y`.
 
-Functions LLVM already lowers to native instructions — `sqrt`, `floor`, `ceil`,
-`round`, `trunc`, `fma`, `abs` — are deliberately **absent**: routing those through
-a library call would be slower than the instruction the compiler emits anyway.
+Deliberately **absent**:
 
-`lgamma` is also absent, because it writes the global `signgam` and so cannot be
-declared side-effect-free.
+  * `sqrt`, `floor`, `ceil`, `round`, `trunc`, `fma`, `abs` — LLVM already lowers
+    these to native instructions, so a library call would be *slower*.
+  * `erf`, `erfc`, `tgamma` — `<simd/math.h>` declares `_simd_erf_f4` and friends,
+    but they measure at 0.97–0.99x of a plain scalar libm loop: they are scalar
+    loops behind a vector signature and buy nothing.
+  * `lgamma` — writes the global `signgam`, so it cannot be declared
+    side-effect-free.
+
+## Measured speedups
+
+`out[i] = f(x[i])` over N = 100,000 on an M-series machine. **`SM/Base`** is
+SIMDMath against a scalar `Base` loop (higher is better); **`SM/vForce`** is against
+`AppleAccelerate.f!` (below 1.0 means vForce wins).
+
+| func | Float32 SM/Base | Float32 SM/vForce | Float64 SM/Base | Float64 SM/vForce |
+|---|---|---|---|---|
+| `sinpi` / `cospi` | **26x** | 0.61x | **7.5x** | 0.45x |
+| `tanpi` | **22x** | 0.78x | **5.9x** | 0.57x |
+| `atan(y,x)` | **10.7x** | 0.73x | 3.9x | 0.62x |
+| `atan` | **10.2x** | 0.69x | 3.4x | 0.53x |
+| `asin` / `acos` | **8.6x** | 0.65x | 3.1–3.7x | 0.51–0.63x |
+| `sin` / `cos` | **8.2x** | 0.57x | 2.5x | 0.51x |
+| `rem` | 6.9x | 0.97x | 3.1x | 0.99x |
+| `expm1` | 6.7x | 0.71x | 3.4x | 0.58x |
+| `pow` | 6.4x | 0.78x | 2.6x | 0.66x |
+| `tan` | 6.4x | 0.64x | 4.0x | 0.52x |
+| `tanh` | 5.7x | 0.78x | 3.2x | 0.57x |
+| `atanh` | 5.2x | 0.57x | 2.1x | 0.54x |
+| `exp2` / `exp` / `exp10` | 4.2–5.0x | 0.57x | 1.5x | 0.68x |
+| `log` / `log2` / `log10` / `log1p` | 3.4–4.5x | 0.55–0.67x | 1.8–2.2x | 0.59–0.65x |
+| `sinh` | 4.4x | 0.66x | 1.6x | 0.57x |
+| `acosh` | 4.1x | 0.56x | 1.1x | 0.52x |
+| `asinh` | 2.5x | 0.65x | 1.1x | 0.60x |
+| `cbrt` | 2.1x | 0.73x | 1.3x | 0.66x |
+| `hypot` | 1.2x | — | 4.5x | — |
+| `cosh` | 1.1x | 0.63x | 1.5x | 0.55x |
+| `nextafter` | — | 0.18x | — | 0.33x |
+
+Reading this:
+
+  * **`SM/vForce` is below 1.0 in every single row.** vForce wins across the board,
+    which is why the guidance above is to prefer it whenever it applies. `nextafter`
+    is the extreme case at 0.18x — always prefer `AppleAccelerate.nextafter!`.
+  * The `Float32` trigonometric functions are where this shines against `Base`,
+    especially `sinpi`/`cospi`/`tanpi`, where `Base` is unusually slow.
+  * `cosh` and `hypot` barely beat `Base` in `Float32` because `Base` implements
+    them natively there — those loops vectorise with no library call at all, so
+    there is little left to win.
+  * `hypot` and `exp10` have no vForce equivalent, so `SIMDMath` is the only
+    accelerated option for them.
 
 ## How it works
 

--- a/docs/src/simdmath.md
+++ b/docs/src/simdmath.md
@@ -59,8 +59,21 @@ end
 
 A call only becomes a SIMD call if the surrounding loop actually vectorises, which
 in practice means `@simd` and usually `@inbounds`. Nothing warns you if it does not
-— the code stays correct and simply runs at scalar speed. To check, look for the
-symbol in the generated code:
+— the code stays correct and simply runs at scalar speed.
+
+!!! note
+    Two common flags silently disable this entirely, because each stops the loop
+    from vectorising at all:
+
+      * **`--check-bounds=yes`** — disables `@inbounds`. This is what `Pkg.test()`
+        passes by default, so `SIMDMath` runs at scalar speed inside a test suite.
+      * **`--code-coverage`** — the counters coverage inserts into the loop body
+        block vectorisation.
+
+    Both leave results correct, just scalar. If you are benchmarking `SIMDMath`,
+    make sure neither is on.
+
+To check, look for the symbol in the generated code:
 
 ```julia
 using InteractiveUtils

--- a/docs/src/simdmath.md
+++ b/docs/src/simdmath.md
@@ -1,0 +1,119 @@
+# SIMD Math in `@simd` Loops
+
+`AppleAccelerate.SIMDMath` exposes scalar math functions that LLVM replaces with
+Apple's SIMD math routines when they appear inside a loop that vectorises.
+
+This is the non-array counterpart to [Array Operations](array.md). Where
+`AppleAccelerate.log!(out, X)` needs a whole array in and a whole array out,
+`SIMDMath.log(x)` is an ordinary scalar call you can put in the middle of a loop.
+
+## When to use it
+
+!!! important
+    **`SIMDMath` is not a faster replacement for the array API.** On an M-series
+    machine, vForce's `vv*` routines (`AppleAccelerate.log!` and friends) are about
+    **2x faster per element** than these SIMD routines at *every* array size measured
+    (N = 16 through 500,000). There is no small-N crossover, and vForce wins even
+    when it needs extra temporary arrays and extra passes over memory.
+
+    If your data is a dense `Array` and you can call `AppleAccelerate.log!`, do that.
+
+`SIMDMath` is for the cases where the array API does not apply:
+
+  * strided or otherwise non-contiguous access;
+  * values computed on the fly rather than read out of an array;
+  * loops with control flow, or over iterables that are not dense `Array`s;
+  * hot paths where you cannot allocate and cannot preallocate a temporary.
+
+In those situations the realistic alternative is a scalar `Base` loop, and `SIMDMath`
+is roughly **2–4x faster for `Float32`** and **1.2–2x for `Float64`**.
+
+```julia
+using AppleAccelerate.SIMDMath: log
+
+# strided access: vForce would need a gather into a temporary first
+function logsum_strided(X, stride)
+    u = zero(eltype(X))
+    @simd for i in 1:stride:length(X)
+        @inbounds u += log(X[i])
+    end
+    u
+end
+```
+
+## Accuracy
+
+!!! warning
+    These routines trade accuracy for speed and are **less accurate than `Base`**,
+    whose math functions are correctly rounded (≤ 0.5 ULP). Worst case measured
+    against `Base` is about **3 ULP**.
+
+    Accuracy is also **not consistent across a single call site**: if the loop
+    vectorises you get the SIMD routine, and if it does not — an unvectorisable
+    loop, or the scalar remainder of one that did — you get the correctly-rounded
+    libm call instead. Two runs over arrays of different length can therefore give
+    slightly different answers. Do not use `SIMDMath` where bitwise reproducibility
+    matters.
+
+## Confirming you got the vectorised form
+
+A call only becomes a SIMD call if the surrounding loop actually vectorises, which
+in practice means `@simd` and usually `@inbounds`. Nothing warns you if it does not
+— the code stays correct and simply runs at scalar speed. To check, look for the
+symbol in the generated code:
+
+```julia
+using InteractiveUtils
+@code_native logsum_strided(rand(1000), 3)   # expect a call to _simd_log_d2
+```
+
+`Float32` runs 4 lanes at a time (`_simd_*_f4`), `Float64` runs 2 (`_simd_*_d2`).
+
+## Available functions
+
+All are defined for `Float32` and `Float64` only.
+
+| | |
+|---|---|
+| One argument | `acos`, `acosh`, `asin`, `asinh`, `atan`, `atanh`, `cbrt`, `cos`, `cosh`, `cospi`, `erf`, `erfc`, `exp`, `exp10`, `exp2`, `expm1`, `log`, `log10`, `log1p`, `log2`, `sin`, `sinh`, `sinpi`, `tan`, `tanh`, `tanpi`, `tgamma` |
+| Two arguments | `atan(y, x)`, `hypot`, `nextafter`, `pow`, `rem`, `remainder` |
+
+`erf`, `erfc`, `tgamma`, `nextafter`, `pow` and `remainder` have no `Base`
+counterpart with matching semantics, so they are named after their C equivalents.
+Use `pow(x, y)` rather than `x^y`.
+
+Functions LLVM already lowers to native instructions — `sqrt`, `floor`, `ceil`,
+`round`, `trunc`, `fma`, `abs` — are deliberately **absent**: routing those through
+a library call would be slower than the instruction the compiler emits anyway.
+
+`lgamma` is also absent, because it writes the global `signgam` and so cannot be
+declared side-effect-free.
+
+## How it works
+
+LLVM's loop vectoriser can replace a scalar call inside a vectorising loop with a
+call to an equivalent SIMD routine, if it is told which routine to use. `clang`
+spells this `-fveclib=Accelerate`. The underlying mechanism is the LLVM *vector
+function ABI* (VFABI), which is driven entirely by IR metadata, so Julia can reach
+it through `llvmcall` — no compiler flag and no patched Julia required.
+
+Each function is emitted as a scalar call to the real libm symbol (`logf`), carrying
+a `"vector-function-abi-variant"` attribute naming the SIMD replacement:
+
+```
+_ZGV_LLVM_N4v_logf(_simd_log_f4)
+```
+
+which reads as "`_LLVM_` ISA, **N**ot masked, **4** lanes, one **v**ector operand,
+mapping scalar `logf` onto vector `_simd_log_f4`". The vector routine must also be
+declared in the module *and* anchored in `@llvm.compiler.used`, or it gets stripped
+before the vectoriser runs and the mapping is silently dropped.
+
+The routines come from libsystem_m's `<simd/math.h>` rather than Accelerate's own
+`vfp.h`. Both are public Apple API, but `vfp.h` is `Float32`-only and covers fewer
+functions, whereas `<simd/math.h>` covers both widths — and since `Float64` is
+Julia's default, using one source for both keeps accuracy consistent across types.
+
+```@docs
+AppleAccelerate.SIMDMath
+```

--- a/src/AppleAccelerate.jl
+++ b/src/AppleAccelerate.jl
@@ -188,6 +188,7 @@ end
 
     include("array.jl")
     include("vmath.jl")
+    include("simdmath.jl")
     include("complexarray.jl")
     include("dsp.jl")
     include("sparse.jl")

--- a/src/simdmath.jl
+++ b/src/simdmath.jl
@@ -137,6 +137,11 @@ in practice means `@simd` (and usually `@inbounds`). Outside a vectorised loop
 these are ordinary — correct, but no faster than `Base`, and sometimes slower.
 `Float32` runs 4 lanes at a time, `Float64` runs 2.
 
+!!! note
+    `--check-bounds=yes` (which `Pkg.test()` passes by default) and `--code-coverage`
+    each stop the loop vectorising at all, silently reducing these to scalar libm
+    calls. Results stay correct; the speedup disappears.
+
 To confirm you are getting the vectorised form, look for the symbol:
 
 ```julia

--- a/src/simdmath.jl
+++ b/src/simdmath.jl
@@ -1,0 +1,250 @@
+## simdmath.jl — scalar math functions that auto-vectorise inside `@simd` loops ##
+#
+# `array.jl` exposes vForce's `vv*` routines, which are *array*-shaped: they need a
+# materialised input array and somewhere to put the output. That shape does not fit
+# every loop — strided access, values computed on the fly, control flow in the loop
+# body, or any iterable that is not a dense `Array`. In those cases the only option
+# today is a scalar `Base` loop.
+#
+# LLVM's loop vectoriser can replace a *scalar* call inside a vectorising loop with
+# a call to an equivalent SIMD routine, provided it is told which routine to use.
+# `clang` spells that `-fveclib=Accelerate`; the underlying mechanism is the LLVM
+# "vector function ABI" (VFABI), which is driven entirely by IR and so is reachable
+# from Julia via `llvmcall` — no compiler flag, no patched Julia. This file uses it
+# to expose Apple's SIMD math routines as ordinary scalar Julia functions that
+# vectorise when (and only when) the surrounding loop does.
+#
+# ## Scope: this does NOT replace the array API
+#
+# Measured on an M-series machine, vForce's `vv*` routines beat these SIMD routines
+# by roughly 2x per element at *every* array size tested (N = 16 … 500_000) — there
+# is no small-N crossover, and vForce still wins even when it needs extra temporary
+# arrays and extra passes over memory. `_simd_log_f4` is simply not as well tuned as
+# `vvlogf`, which can unroll and pipeline across a long array in a way a single
+# 4-lane call cannot.
+#
+# So: **if the data is a dense array and you can call `AppleAccelerate.log!`, do
+# that instead — it is faster.** These functions are for the cases where that is not
+# an option, where the honest comparison is against a scalar `Base` loop, and where
+# they run about 2–4x faster (Float32) or 1.2–2x faster (Float64).
+#
+# ## How the generated IR works
+#
+# For each function three things must be true, or the mapping is silently ignored
+# and you get a scalar libm call back:
+#
+#   1. The scalar call must be to a *named symbol* (`@logf`), not an opaque Julia
+#      function, so the vectoriser has something to match on.
+#   2. The vector routine (`@_simd_log_f4`) must be *declared in the module*.
+#      `VFDatabase` looks it up by name and drops the mapping if it is absent.
+#   3. That declaration must be anchored in `@llvm.compiler.used`. Without it the
+#      declaration is unreferenced at the point the vectoriser runs, gets stripped
+#      by earlier passes, rule 2 fails, and everything silently falls back to
+#      scalar. This is the single easiest step to miss.
+#
+# The mapping itself is the `"vector-function-abi-variant"` attribute on the call,
+# whose value is a VFABI-mangled string: `_ZGV_LLVM_N4v_logf(_simd_log_f4)` reads
+# as "the `_LLVM_` ISA, Not masked, 4 lanes, one vector operand, mapping scalar
+# `logf` onto vector `_simd_log_f4`".
+#
+# ## Why `_simd_*` and not Accelerate's `vfp.h`
+#
+# Accelerate's own `vfp.h` SIMD entry points (`vlogf`, `vexpf`, …) are Float32-only
+# and cover 22 functions. libsystem_m's `<simd/math.h>` (`_simd_log_f4`,
+# `_simd_log_d2`, …) is public SDK API, covers the same ground plus Float64, and is
+# what recent LLVM prefers on Darwin. Since Float64 is Julia's default, using one
+# source for both widths keeps accuracy consistent across `Float32`/`Float64`
+# rather than mixing two vendors' implementations.
+#
+# ## Accuracy
+#
+# These routines are *less accurate than Base*. See the `SIMDMath` docstring; the
+# tolerances are pinned in `test/simdmath_tests.jl`.
+
+"""
+    AppleAccelerate.SIMDMath
+
+Scalar math functions that LLVM replaces with Apple's SIMD math routines when they
+appear inside a vectorised loop.
+
+Unlike the array functions in `AppleAccelerate` proper (which wrap vForce and need
+a whole array to work on), these are *scalar* functions called from inside a `@simd`
+loop:
+
+```julia
+using AppleAccelerate.SIMDMath: log
+
+# strided access — vForce cannot be used here without gathering into a temporary
+function logsum_strided(X, stride)
+    u = zero(eltype(X))
+    @simd for i in 1:stride:length(X)
+        @inbounds u += log(X[i])
+    end
+    u
+end
+```
+
+# When to use this — and when not to
+
+!!! important
+    **This is not a faster replacement for the array API.** vForce's `vv*` routines
+    (`AppleAccelerate.log!` and friends) are about 2x faster per element than these
+    SIMD routines at every array size measured, and win even when they need extra
+    temporaries and extra passes over memory. If your data is a dense array, use
+    those instead.
+
+`SIMDMath` is for the cases where vForce does not apply:
+
+  * strided or otherwise non-contiguous access;
+  * values computed on the fly rather than read from an array;
+  * loops with control flow, or over iterables that are not dense `Array`s;
+  * hot paths where you cannot allocate and cannot preallocate a temporary.
+
+There, the realistic alternative is a scalar `Base` loop, against which these run
+roughly 2–4x faster for `Float32` and 1.2–2x for `Float64`.
+
+# Accuracy
+
+!!! warning
+    These routines trade accuracy for speed and are **less accurate than the
+    equivalent `Base` functions**, which are correctly rounded (≤ 0.5 ULP).
+    Measured worst case is roughly 1–3 ULP depending on the function; see
+    `test/simdmath_tests.jl` for the pinned per-function bounds.
+
+    Accuracy is also **not consistent across the same call site**. If the loop
+    vectorises you get the SIMD routine; if it does not (an unvectorisable loop,
+    or the scalar remainder of one that did) you get the correctly-rounded libm
+    call instead. Do not use these where reproducibility across loop shapes
+    matters.
+
+# Vectorising
+
+A call only becomes a SIMD call if the surrounding loop actually vectorises, which
+in practice means `@simd` (and usually `@inbounds`). Outside a vectorised loop
+these are ordinary — correct, but no faster than `Base`, and sometimes slower.
+`Float32` runs 4 lanes at a time, `Float64` runs 2.
+
+To confirm you are getting the vectorised form, look for the symbol:
+
+```julia
+using InteractiveUtils
+@code_native weighted_logsum(X, W)   # expect a call to _simd_log_d2
+```
+
+# Available functions
+
+One argument: `acos`, `acosh`, `asin`, `asinh`, `atan`, `atanh`, `cbrt`, `cos`,
+`cosh`, `cospi`, `erf`, `erfc`, `exp`, `exp10`, `exp2`, `expm1`, `log`, `log10`,
+`log1p`, `log2`, `sin`, `sinh`, `sinpi`, `tan`, `tanh`, `tanpi`, `tgamma`.
+
+Two arguments: `atan(y, x)`, `hypot`, `nextafter`, `pow`, `rem`, `remainder`.
+
+All are defined for `Float32` and `Float64` only. Functions LLVM already lowers to
+native instructions (`sqrt`, `floor`, `ceil`, `round`, `trunc`, `fma`, `abs`) are
+deliberately absent — routing those through a library call would be slower.
+
+`erf`, `erfc`, `tgamma`, `nextafter`, `pow` and `remainder` have no `Base`
+counterpart with matching semantics and are named after their C equivalents.
+"""
+module SIMDMath
+
+# Functions LLVM lowers natively (sqrt/floor/ceil/round/trunc/fma/fabs) are
+# excluded on purpose: a libcall would be slower than the instruction.
+
+# (Julia name, C scalar symbol for Float64, C scalar symbol for Float32,
+#  `<simd/math.h>` base name -- `_simd_<base>_d2` / `_simd_<base>_f4`)
+#
+# The C scalar name is what the *unvectorised* path calls, so it has to be the real
+# libm symbol. It is usually `<base>` for Float64 and `<base>f` for Float32, but
+# Darwin spells a few with a leading underscore pair, hence the explicit columns.
+const UNARY = (
+    # (jlname,   c64,        c32,         simd base)
+    (:acos,     "acos",     "acosf",     "acos"),
+    (:acosh,    "acosh",    "acoshf",    "acosh"),
+    (:asin,     "asin",     "asinf",     "asin"),
+    (:asinh,    "asinh",    "asinhf",    "asinh"),
+    (:atan,     "atan",     "atanf",     "atan"),
+    (:atanh,    "atanh",    "atanhf",    "atanh"),
+    (:cbrt,     "cbrt",     "cbrtf",     "cbrt"),
+    (:cos,      "cos",      "cosf",      "cos"),
+    (:cosh,     "cosh",     "coshf",     "cosh"),
+    (:cospi,    "__cospi",  "__cospif",  "cospi"),
+    (:erf,      "erf",      "erff",      "erf"),
+    (:erfc,     "erfc",     "erfcf",     "erfc"),
+    (:exp,      "exp",      "expf",      "exp"),
+    (:exp10,    "__exp10",  "__exp10f",  "exp10"),
+    (:exp2,     "exp2",     "exp2f",     "exp2"),
+    (:expm1,    "expm1",    "expm1f",    "expm1"),
+    (:log,      "log",      "logf",      "log"),
+    (:log10,    "log10",    "log10f",    "log10"),
+    (:log1p,    "log1p",    "log1pf",    "log1p"),
+    (:log2,     "log2",     "log2f",     "log2"),
+    (:sin,      "sin",      "sinf",      "sin"),
+    (:sinh,     "sinh",     "sinhf",     "sinh"),
+    (:sinpi,    "__sinpi",  "__sinpif",  "sinpi"),
+    (:tan,      "tan",      "tanf",      "tan"),
+    (:tanh,     "tanh",     "tanhf",     "tanh"),
+    (:tanpi,    "__tanpi",  "__tanpif",  "tanpi"),
+    (:tgamma,   "tgamma",   "tgammaf",   "tgamma"),
+)
+# `lgamma` is deliberately omitted: it writes the global `signgam`, which the
+# `memory(none)` declaration below would let LLVM assume never happens.
+
+const BINARY = (
+    # (jlname,     c64,          c32,           simd base)
+    (:atan,       "atan2",      "atan2f",      "atan2"),
+    (:hypot,      "hypot",      "hypotf",      "hypot"),
+    (:nextafter,  "nextafter",  "nextafterf",  "nextafter"),
+    (:pow,        "pow",        "powf",        "pow"),
+    (:rem,        "fmod",       "fmodf",       "fmod"),
+    (:remainder,  "remainder",  "remainderf",  "remainder"),
+)
+
+"""
+    _ir(cname, vecname, W, lt, nargs) -> String
+
+Build the `llvmcall` module for one function: a scalar call to `cname` carrying a
+VFABI mapping onto the `W`-lane `vecname`, with `vecname` anchored in
+`@llvm.compiler.used` so it survives to the loop vectoriser.
+"""
+function _ir(cname::String, vecname::String, W::Int, lt::String, nargs::Int)
+    formals = join(("$lt %$(i-1)" for i in 1:nargs), ", ")
+    actuals = formals
+    scalar_tys = join((lt for _ in 1:nargs), ", ")
+    vector_tys = join(("<$W x $lt>" for _ in 1:nargs), ", ")
+    vtok = "v"^nargs
+    """
+    @llvm.compiler.used = appending global [1 x ptr] [ptr @"$vecname"], section "llvm.metadata"
+    declare <$W x $lt> @"$vecname"($vector_tys)
+    declare $lt @"$cname"($scalar_tys) #0
+    define $lt @entry($formals) #2 {
+    top:
+      %r = call $lt @"$cname"($actuals) #1
+      ret $lt %r
+    }
+    attributes #0 = { nounwind willreturn memory(none) }
+    attributes #1 = { "vector-function-abi-variant"="_ZGV_LLVM_N$W$(vtok)_$cname($vecname)" }
+    attributes #2 = { alwaysinline nounwind willreturn memory(none) }
+    """
+end
+
+# The scalar declaration is `memory(none)`, i.e. errno is assumed untouched. Julia
+# never reads math errno, and this is the same assumption clang makes under
+# -fno-math-errno; without it the calls could not be hoisted or vectorised at all.
+
+for (tbl, nargs) in ((UNARY, 1), (BINARY, 2))
+    for (jlname, c64, c32, simd) in tbl
+        for (T, lt, cname, W, suffix) in ((Float64, "double", c64, 2, "d2"),
+                                          (Float32, "float",  c32, 4, "f4"))
+            ir = _ir(cname, "_simd_$(simd)_$(suffix)", W, lt, nargs)
+            args = [Symbol(:x, i) for i in 1:nargs]
+            sig = [:($(args[i])::$T) for i in 1:nargs]
+            argtys = [T for _ in 1:nargs]
+            @eval @inline function $jlname($(sig...))
+                Base.llvmcall(($ir, "entry"), $T, Tuple{$(argtys...)}, $(args...))
+            end
+        end
+    end
+end
+
+end # module SIMDMath

--- a/src/simdmath.jl
+++ b/src/simdmath.jl
@@ -60,6 +60,19 @@
 #
 # These routines are *less accurate than Base*. See the `SIMDMath` docstring; the
 # tolerances are pinned in `test/simdmath_tests.jl`.
+#
+# ## Why the package needs Julia >= 1.11
+#
+# The IR below is LLVM 16+. Julia 1.11 ships LLVM 16, Julia 1.10 ships LLVM 15, and
+# two things here do not exist in 15:
+#
+#   * opaque pointers (`ptr`). On LLVM 15 `@llvm.compiler.used` has to be spelled
+#     `[1 x i8*]` with an explicit `bitcast` of the typed function pointer.
+#   * the `memory(none)` attribute, which was `readnone` before LLVM 16.
+#
+# Emitting both dialects is possible but doubles the surface for one superseded
+# LLVM, so `julia = "1.11"` is the floor instead. On 1.10 this file fails to parse
+# with `error: expected type` at the `ptr` in `[1 x ptr]`.
 
 """
     AppleAccelerate.SIMDMath

--- a/src/simdmath.jl
+++ b/src/simdmath.jl
@@ -134,17 +134,23 @@ using InteractiveUtils
 # Available functions
 
 One argument: `acos`, `acosh`, `asin`, `asinh`, `atan`, `atanh`, `cbrt`, `cos`,
-`cosh`, `cospi`, `erf`, `erfc`, `exp`, `exp10`, `exp2`, `expm1`, `log`, `log10`,
-`log1p`, `log2`, `sin`, `sinh`, `sinpi`, `tan`, `tanh`, `tanpi`, `tgamma`.
+`cosh`, `cospi`, `exp`, `exp10`, `exp2`, `expm1`, `log`, `log10`, `log1p`, `log2`,
+`sin`, `sinh`, `sinpi`, `tan`, `tanh`, `tanpi`.
 
 Two arguments: `atan(y, x)`, `hypot`, `nextafter`, `pow`, `rem`, `remainder`.
 
-All are defined for `Float32` and `Float64` only. Functions LLVM already lowers to
-native instructions (`sqrt`, `floor`, `ceil`, `round`, `trunc`, `fma`, `abs`) are
-deliberately absent — routing those through a library call would be slower.
+All are defined for `Float32` and `Float64` only. `nextafter`, `pow` and `remainder`
+have no `Base` counterpart with matching semantics and are named after their C
+equivalents; use `pow(x, y)` rather than `x^y`.
 
-`erf`, `erfc`, `tgamma`, `nextafter`, `pow` and `remainder` have no `Base`
-counterpart with matching semantics and are named after their C equivalents.
+Deliberately absent:
+
+  * `sqrt`, `floor`, `ceil`, `round`, `trunc`, `fma`, `abs` — LLVM already lowers
+    these to native instructions, so a library call would be *slower*.
+  * `erf`, `erfc`, `tgamma` — `<simd/math.h>` declares these, but they measure at
+    0.97–0.99x of a scalar libm loop: they are scalar loops behind a vector
+    signature and buy nothing.
+  * `lgamma` — writes the global `signgam`, so it cannot be declared `memory(none)`.
 """
 module SIMDMath
 
@@ -169,8 +175,6 @@ const UNARY = (
     (:cos,      "cos",      "cosf",      "cos"),
     (:cosh,     "cosh",     "coshf",     "cosh"),
     (:cospi,    "__cospi",  "__cospif",  "cospi"),
-    (:erf,      "erf",      "erff",      "erf"),
-    (:erfc,     "erfc",     "erfcf",     "erfc"),
     (:exp,      "exp",      "expf",      "exp"),
     (:exp10,    "__exp10",  "__exp10f",  "exp10"),
     (:exp2,     "exp2",     "exp2f",     "exp2"),
@@ -185,10 +189,14 @@ const UNARY = (
     (:tan,      "tan",      "tanf",      "tan"),
     (:tanh,     "tanh",     "tanhf",     "tanh"),
     (:tanpi,    "__tanpi",  "__tanpif",  "tanpi"),
-    (:tgamma,   "tgamma",   "tgammaf",   "tgamma"),
 )
 # `lgamma` is deliberately omitted: it writes the global `signgam`, which the
 # `memory(none)` declaration below would let LLVM assume never happens.
+#
+# `erf`, `erfc` and `tgamma` are omitted despite `<simd/math.h>` declaring
+# `_simd_erf_f4` and friends: measured against a plain scalar libm loop they come
+# out at 0.97-0.99x, i.e. those routines are scalar loops behind a vector signature
+# and buy nothing. Exposing them would advertise an acceleration that is not there.
 
 const BINARY = (
     # (jlname,     c64,          c32,           simd base)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -18,6 +18,7 @@ N = 1_000
 include("lib_tests.jl")
 include("array_tests.jl")
 include("vmath_tests.jl")
+include("simdmath_tests.jl")
 include("complexarray_tests.jl")
 include("dsp_tests.jl")
 include("sparse_tests.jl")

--- a/test/simdmath_tests.jl
+++ b/test/simdmath_tests.jl
@@ -1,0 +1,163 @@
+const SM = AppleAccelerate.SIMDMath
+
+# Inputs inside each function's real domain, so the reference never returns NaN and
+# the comparison actually tests something.
+function _simd_domain(S::Symbol, ::Type{T}, n::Int) where {T}
+    r = rand(T, n)
+    S in (:acos, :asin, :atanh)                ? (r .* T(1.8) .- T(0.9)) :
+    S in (:acosh,)                             ? (r .* T(4) .+ T(1.1)) :
+    S in (:log, :log2, :log10, :cbrt, :tgamma) ? (r .* T(8) .+ T(0.3)) :
+    S in (:log1p,)                             ? (r .* T(4)) :
+    S in (:exp, :exp2, :exp10)                 ? (r .* T(4) .- T(2)) :
+    S in (:sinpi, :cospi, :tanpi)              ? (r .* T(3) .- T(1.5)) :
+                                                 (r .* T(2) .- T(1))
+end
+
+_ulps(got::T, ref::T) where {T} = got == ref ? 0.0 : Float64(abs(big(got) - big(ref)) / eps(ref))
+
+# Deliberately loose: these routines trade accuracy for speed, and the worst observed
+# on macOS 26 / M-series was 3 ULP (tanpi, Float64). The bound exists to catch a
+# broken *mapping* in the UNARY / BINARY tables, not to pin an accuracy contract.
+const ULP_TOL = 8.0
+
+# The whole point of this module is that the scalar call is replaced by a call to the
+# SIMD routine. If that silently stops happening the functions still return correct
+# answers, just slowly -- so assert on the emitted code, not only on the numbers.
+#
+# This has to run in a child process. Vectorisation only happens when `@inbounds` is
+# honoured, and `Pkg.test()` defaults to `--check-bounds=yes`, which disables it and
+# blocks vectorisation outright. Checking in-process would mean this test silently
+# never runs under CI -- precisely where a regression would slip through -- so spawn
+# a child with the default bounds-checking setting instead.
+const _VECTORISE_CHECK = raw"""
+using AppleAccelerate, InteractiveUtils
+const SM = AppleAccelerate.SIMDMath
+failures = String[]
+for (tbl, nargs) in ((SM.UNARY, 1), (SM.BINARY, 2))
+    for (jlname, _c64, _c32, simd) in tbl
+        f = getfield(SM, jlname)
+        for (T, suffix) in ((Float64, "d2"), (Float32, "f4"))
+            sym = "_simd_$(simd)_$(suffix)"
+            g = nargs == 1 ?
+                (o, x) -> (@simd for i in eachindex(x, o); @inbounds o[i] = f(x[i]); end; o) :
+                (o, x, y) -> (@simd for i in eachindex(x, o); @inbounds o[i] = f(x[i], y[i]); end; o)
+            argtypes = ntuple(_ -> Vector{T}, nargs + 1)
+            io = IOBuffer()
+            code_native(io, g, argtypes; debuginfo = :none)
+            occursin(Regex("\\b_" * sym * "\\b"), String(take!(io))) || push!(failures, "$jlname/$T -> $sym")
+        end
+    end
+end
+print(join(failures, ","))
+"""
+
+@testset "SIMDMath" begin
+
+    @testset "vectorises to the SIMD routine" begin
+        script = tempname() * ".jl"
+        write(script, _VECTORISE_CHECK)
+        try
+            out = read(`$(Base.julia_cmd()) --check-bounds=auto --startup-file=no
+                        --project=$(Base.active_project()) $script`, String)
+            failed = filter(!isempty, split(out, ","))
+            # Name the offenders rather than just asserting a count, so a regression
+            # points straight at the broken mapping.
+            @test failed == SubString{String}[]
+        finally
+            rm(script; force = true)
+        end
+    end
+
+    # Cross-check against Base. This is what catches a wrong entry in the UNARY /
+    # BINARY tables -- a mismapped name or (for atan2) a swapped argument order
+    # produces a completely different number, not a few-ULP difference.
+    @testset "matches Base (1-arg)" begin
+        for (jlname, basef) in ((:acos, acos), (:acosh, acosh), (:asin, asin), (:asinh, asinh),
+                                (:atan, atan), (:atanh, atanh), (:cbrt, cbrt), (:cos, cos),
+                                (:cosh, cosh), (:cospi, cospi), (:exp, exp), (:exp10, exp10),
+                                (:exp2, exp2), (:expm1, expm1), (:log, log), (:log10, log10),
+                                (:log1p, log1p), (:log2, log2), (:sin, sin), (:sinh, sinh),
+                                (:sinpi, sinpi), (:tan, tan), (:tanh, tanh), (:tanpi, tanpi))
+            f = getfield(SM, jlname)
+            for T in (Float32, Float64)
+                X = _simd_domain(jlname, T, N)
+                worst = maximum(eachindex(X)) do i
+                    ref = basef(X[i])
+                    (isfinite(ref) && ref != 0) ? _ulps(f(X[i]), ref) : 0.0
+                end
+                @test worst <= ULP_TOL
+            end
+        end
+    end
+
+    @testset "matches Base (2-arg)" begin
+        for T in (Float32, Float64)
+            X = _simd_domain(:atan, T, N)
+            Y = abs.(_simd_domain(:atan, T, N)) .+ T(0.5)
+            # atan(y, x) must keep Base's argument order, not C's atan2 order by accident
+            @test maximum(i -> _ulps(SM.atan(X[i], Y[i]), atan(X[i], Y[i])), eachindex(X)) <= ULP_TOL
+            @test maximum(i -> _ulps(SM.hypot(X[i], Y[i]), hypot(X[i], Y[i])), eachindex(X)) <= ULP_TOL
+            @test maximum(i -> _ulps(SM.rem(X[i], Y[i]), rem(X[i], Y[i])), eachindex(X)) <= ULP_TOL
+
+            B = abs.(rand(T, N)) .+ T(0.5)
+            E = rand(T, N) .* T(3)
+            @test maximum(i -> _ulps(SM.pow(B[i], E[i]), B[i]^E[i]), eachindex(B)) <= ULP_TOL
+        end
+    end
+
+    # No Base equivalent, so pin against the identities instead of a reference impl.
+    @testset "erf / erfc / tgamma / remainder / nextafter" begin
+        for T in (Float32, Float64)
+            X = _simd_domain(:erf, T, 256)
+            @test all(i -> SM.erf(X[i]) + SM.erfc(X[i]) ≈ one(T), eachindex(X))
+            @test SM.erf(zero(T)) == zero(T)
+            # tgamma(n+1) == n!
+            for n in 1:8
+                @test SM.tgamma(T(n + 1)) ≈ T(factorial(n)) rtol = sqrt(eps(T))
+            end
+            @test SM.nextafter(one(T), T(2)) === nextfloat(one(T))
+            @test SM.nextafter(one(T), zero(T)) === prevfloat(one(T))
+            @test SM.remainder(T(5), T(3)) ≈ T(-1)
+        end
+    end
+
+    # Outside a vectorised loop these must still be correct -- that path calls the
+    # scalar libm symbol, which is a different code path from the SIMD routine.
+    @testset "scalar path (unvectorised) is correct" begin
+        for T in (Float32, Float64)
+            @test SM.log(T(1)) == zero(T)
+            @test SM.exp(zero(T)) == one(T)
+            @test SM.sin(zero(T)) == zero(T)
+            @test SM.cos(zero(T)) == one(T)
+            @test SM.log(SM.exp(T(2))) ≈ T(2)
+            @test SM.sinpi(T(1)) ≈ zero(T) atol = eps(T)
+            @test SM.cospi(zero(T)) == one(T)
+            @test SM.pow(T(2), T(10)) ≈ T(1024)
+            @test SM.hypot(T(3), T(4)) ≈ T(5)
+        end
+    end
+
+    # A vectorised loop and its scalar remainder take different code paths; a length
+    # that is not a multiple of the vector width exercises both in one call.
+    @testset "vector body and scalar remainder agree" begin
+        for T in (Float32, Float64), n in (1, 2, 3, 5, 7, 8, 15, 31, 33)
+            X = abs.(rand(T, n)) .+ T(0.5)
+            O = similar(X)
+            @simd for i in eachindex(X, O)
+                @inbounds O[i] = SM.log(X[i])
+            end
+            @test all(i -> _ulps(O[i], log(X[i])) <= ULP_TOL, eachindex(X))
+        end
+    end
+
+    @testset "type stability" begin
+        for T in (Float32, Float64)
+            @test @inferred(SM.log(one(T))) isa T
+            @test @inferred(SM.pow(T(2), T(3))) isa T
+            @test @inferred(SM.atan(one(T), one(T))) isa T
+        end
+        # Float32 in must not silently widen to Float64
+        @test SM.log(1.5f0) isa Float32
+        @test SM.log(1.5) isa Float64
+    end
+end

--- a/test/simdmath_tests.jl
+++ b/test/simdmath_tests.jl
@@ -105,19 +105,29 @@ print(join(failures, ","))
         end
     end
 
-    # No Base equivalent, so pin against the identities instead of a reference impl.
-    @testset "erf / erfc / tgamma / remainder / nextafter" begin
+    # No Base equivalent, so pin against known values instead of a reference impl.
+    @testset "remainder / nextafter" begin
         for T in (Float32, Float64)
-            X = _simd_domain(:erf, T, 256)
-            @test all(i -> SM.erf(X[i]) + SM.erfc(X[i]) ≈ one(T), eachindex(X))
-            @test SM.erf(zero(T)) == zero(T)
-            # tgamma(n+1) == n!
-            for n in 1:8
-                @test SM.tgamma(T(n + 1)) ≈ T(factorial(n)) rtol = sqrt(eps(T))
-            end
             @test SM.nextafter(one(T), T(2)) === nextfloat(one(T))
             @test SM.nextafter(one(T), zero(T)) === prevfloat(one(T))
             @test SM.remainder(T(5), T(3)) ≈ T(-1)
+        end
+    end
+
+    # Some functions are intentionally not provided; see the note in src/simdmath.jl.
+    # Assert on the tables rather than isdefined(SM, f): every module implicitly does
+    # `using Base`, so isdefined(SM, :sqrt) is true regardless of what we define.
+    @testset "unaccelerated functions stay out" begin
+        provided = Set(Symbol[first(t) for t in (SM.UNARY..., SM.BINARY...)])
+        # measured at ~0.98x of a scalar libm loop -- vector signature, scalar guts
+        @test :erf ∉ provided
+        @test :erfc ∉ provided
+        @test :tgamma ∉ provided
+        # writes the global signgam, so it cannot be declared memory(none)
+        @test :lgamma ∉ provided
+        # LLVM lowers these to native instructions; a libcall would be slower
+        for f in (:sqrt, :floor, :ceil, :round, :trunc, :fma, :abs, :fabs)
+            @test f ∉ provided
         end
     end
 

--- a/test/simdmath_tests.jl
+++ b/test/simdmath_tests.jl
@@ -24,11 +24,18 @@ const ULP_TOL = 8.0
 # SIMD routine. If that silently stops happening the functions still return correct
 # answers, just slowly -- so assert on the emitted code, not only on the numbers.
 #
-# This has to run in a child process. Vectorisation only happens when `@inbounds` is
-# honoured, and `Pkg.test()` defaults to `--check-bounds=yes`, which disables it and
-# blocks vectorisation outright. Checking in-process would mean this test silently
-# never runs under CI -- precisely where a regression would slip through -- so spawn
-# a child with the default bounds-checking setting instead.
+# This has to run in a child process, because two things the *test harness* does each
+# independently stop the loop from vectorising at all:
+#
+#   * `Pkg.test()` defaults to `--check-bounds=yes`, which disables `@inbounds`;
+#   * `julia-actions/julia-runtest` defaults to coverage on, and the counters
+#     coverage inserts into the loop body block vectorisation outright.
+#
+# Neither affects correctness, so the numeric tests above stay green and only this
+# check would fail -- in CI only, which is exactly where a real regression needs
+# catching. So spawn a child with both explicitly turned off. `Base.julia_cmd()`
+# propagates the parent's `--check-bounds` and `--code-coverage`, so both have to be
+# overridden here; the last occurrence of a flag wins.
 const _VECTORISE_CHECK = raw"""
 using AppleAccelerate, InteractiveUtils
 const SM = AppleAccelerate.SIMDMath
@@ -57,8 +64,8 @@ print(join(failures, ","))
         script = tempname() * ".jl"
         write(script, _VECTORISE_CHECK)
         try
-            out = read(`$(Base.julia_cmd()) --check-bounds=auto --startup-file=no
-                        --project=$(Base.active_project()) $script`, String)
+            out = read(`$(Base.julia_cmd()) --check-bounds=auto --code-coverage=none
+                        --startup-file=no --project=$(Base.active_project()) $script`, String)
             failed = filter(!isempty, split(out, ","))
             # Name the offenders rather than just asserting a count, so a regression
             # points straight at the broken mapping.


### PR DESCRIPTION
Closes #10.

#10 asked to expose Apple's non-array SIMD math routines so a plain `@simd` loop
could use them. The 2016 discussion concluded it needed a patched Julia. That is no
longer true — this works on released Julia (tested on 1.12.6 / LLVM 18.1.7) with no
compiler flag.

## How

LLVM's loop vectoriser can replace a *scalar* call inside a vectorising loop with an
equivalent SIMD routine, if it is told which one — that's what `clang -fveclib=Accelerate`
does. The mechanism underneath is the LLVM **vector function ABI**, which is driven
entirely by IR, so `llvmcall` can reach it directly.

Each function is emitted as a scalar call to the real libm symbol, carrying a
`"vector-function-abi-variant"` attribute naming its SIMD replacement:

```
_ZGV_LLVM_N4v_logf(_simd_log_f4)
```

("`_LLVM_` ISA, **N**ot masked, **4** lanes, one **v**ector operand, map scalar `logf`
onto vector `_simd_log_f4`".)

```julia
using AppleAccelerate.SIMDMath: log

function logsum_strided(X, stride)
    u = zero(eltype(X))
    @simd for i in 1:stride:length(X)
        @inbounds u += log(X[i])
    end
    u
end
```

emits `bl __simd_log_d2`, 2 lanes at a time.

## Scope — this is *not* a faster array API

I want to be upfront about this, because it's the main thing a reviewer should push
back on. Benchmarked across **all 30 mappings** (`out[i] = f(x[i])`, N=100,000,
M-series):

| | Float32 | Float64 |
|---|---|---|
| SIMDMath vs scalar `Base` loop | **1.1x – 27x faster** | **1.1x – 7.5x faster** |
| SIMDMath vs vForce `f!` | **0.18x – 0.97x** (always loses) | **0.45x – 0.99x** (always loses) |

**vForce wins in every single row** — there is no function where SIMDMath beats it,
no small-N crossover (checked N = 16 … 500,000), and it still wins when it needs
extra temporaries and extra passes over memory. `vvlogf` can unroll and pipeline
across a long array in a way a single 4-lane call cannot.

So `SIMDMath` is **not** a replacement for `array.jl`, and the docs say so plainly.
It's for loops the array API can't express:

* strided or non-contiguous access;
* values computed on the fly rather than read from an array;
* control flow in the loop body, or non-dense-`Array` iterables;
* hot paths that can neither allocate nor preallocate a temporary.

There the realistic alternative is a scalar `Base` loop — the first row above.

### Where it helps most (vs a scalar `Base` loop)

| func | F32 | F64 | |
|---|---|---|---|
| `sinpi` / `cospi` | **26x** | 7.5x | `Base` is unusually slow here |
| `tanpi` | **22x** | 5.9x | |
| `atan(y,x)` / `atan` | **10x** | 3.4x | |
| `asin` / `acos` / `sin` / `cos` | **8.2–8.9x** | 2.5–3.7x | |
| `pow` / `tan` / `expm1` / `rem` | 6.4–6.9x | 2.6–4.0x | |
| `exp` / `log` family | 3.4–5.0x | 1.5–2.2x | |
| `cbrt` / `asinh` | 2.1–2.5x | 1.1–1.3x | thin |
| `cosh` / `hypot` (F32) | **1.1–1.2x** | 1.5–4.5x | `Base` already vectorises these natively in F32 — no libcall to beat |

`hypot` and `exp10` have no vForce equivalent, so SIMDMath is the only accelerated
option for them. `nextafter` is the worst case at **0.18x of vForce** — always prefer
`AppleAccelerate.nextafter!` there.

Full per-function table is in the docs page.

This also revisits the `vmath.jl` note that `vfp.h` is "intentionally left to the raw
layer" because register-width SIMD has no idiomatic array surface. That reasoning
still holds for the raw types — but this route sidesteps it: the user never touches a
SIMD type, they write a scalar loop and LLVM does the widening.

## Why `<simd/math.h>` and not Accelerate's `vfp.h`

Both are public Apple API. `vfp.h` (`vlogf`, …) is Float32-only and covers 22
functions; libsystem_m's `<simd/math.h>` covers both widths and more functions. Since
Float64 is Julia's default, using one source for both keeps accuracy consistent across
types rather than mixing two vendors' implementations.

Worth flagging for review: this means the module is technically libsystem_m rather
than Accelerate proper. Happy to switch to `vfp.h` for Float32 if you'd rather keep
the package strictly Accelerate, at the cost of Float64 coverage.

## Accuracy — please read

These routines trade accuracy for speed. Worst case measured vs `Base` (which is
correctly rounded, ≤0.5 ULP) is **~3 ULP** (`tanpi`, Float64).

Accuracy is also **not consistent across a single call site**: the scalar remainder of
a vectorised loop calls libm and *is* correctly rounded, while the vector body is not.
So two runs over arrays of different length can give slightly different answers. Both
caveats are documented in the module docstring and the docs page.

## API

`Float32` and `Float64` only. 30 mappings.

* **1-arg:** `acos`, `acosh`, `asin`, `asinh`, `atan`, `atanh`, `cbrt`, `cos`, `cosh`,
  `cospi`, `exp`, `exp10`, `exp2`, `expm1`, `log`, `log10`, `log1p`, `log2`, `sin`,
  `sinh`, `sinpi`, `tan`, `tanh`, `tanpi`
* **2-arg:** `atan(y, x)`, `hypot`, `nextafter`, `pow`, `rem`, `remainder`

Deliberately omitted:

* `sqrt`/`floor`/`ceil`/`round`/`trunc`/`fma`/`abs` — LLVM already lowers these to
  native instructions; a libcall would be *slower*.
* **`erf`, `erfc`, `tgamma`** — `<simd/math.h>` declares `_simd_erf_f4` and friends,
  and the mapping does fire (the emitted code really calls them), but they measure at
  **0.97–0.99x of a plain scalar libm loop**: scalar loops behind a vector signature.
  Exposing them would advertise acceleration that isn't there, and unlike `cosh` there's
  no `Base` fallback story, so they're removed rather than documented as slow. A test
  asserts they stay out so nobody re-adds them without re-measuring.
* `lgamma` — writes the global `signgam`, so it can't be declared `memory(none)`.

## Raises the minimum Julia to 1.11

CI's `Julia min` job caught this: the generated IR is LLVM 16+, and Julia 1.10 ships
LLVM 15, which predates two things it relies on:

* **opaque pointers** (`ptr`) — on LLVM 15, `@llvm.compiler.used` must be spelled
  `[1 x i8*]` with an explicit bitcast of the typed function pointer;
* **`memory(none)`** — spelled `readnone` before LLVM 16.

On 1.10 it fails with `Failed to parse LLVM assembly: <string>:1:45: error: expected
type` (column 45 is the `ptr` in `[1 x ptr]`).

Emitting both dialects is possible but doubles the surface of the IR builder for one
superseded LLVM, so this raises `julia = "1.11"` instead. Julia 1.11 ships LLVM 16
and needs no changes — verified locally on **1.11 (LLVM 16.0.6)** and **1.12 (LLVM
18.1.7)**.

Flagging for review since **1.10 is the current LTS**. It rides along with the
0.7 → 0.8 break already in flight from #175 rather than forcing a separate breaking
release. If dropping LTS support is unacceptable, the alternative is emitting the
LLVM 15 dialect behind a `Base.libllvm_version` check — happy to do that instead.

The CI `min` job reads the compat entry, so no workflow change was needed.

## Two implementation notes worth knowing

**`@llvm.compiler.used` is load-bearing.** The vector declaration has to be anchored
there. Without it, the unreferenced declaration is stripped before the vectoriser
runs, `VFDatabase`'s lookup of the vector function fails, and *every call silently
falls back to scalar* — still correct, just slow, with no diagnostic. This is the
easiest part of the mechanism to lose in a refactor.

**Two common flags disable this entirely.** Each independently stops the loop
vectorising, silently reducing every call to a scalar libm call — correct results, no
speedup, no diagnostic:

* `--check-bounds=yes` (disables `@inbounds`) — what `Pkg.test()` passes by default;
* `--code-coverage` (its counters in the loop body block vectorisation) — what
  `julia-actions/julia-runtest` enables by default.

Both are documented for users. They also had to be overridden in the test's child
process, which inherits them via `Base.julia_cmd()`.

## Testing

The suite asserts on **emitted code**, not just numbers — a broken mapping stays
numerically correct, so numeric tests alone can't catch it. Because of the
`--check-bounds` interaction above, that check runs in a child process with
`--check-bounds=auto`; done in-process it would silently never run in CI, which is
exactly where it matters. A failure names the offending mappings.

Verified while developing this:

* all 60 function/type mappings emit the expected `_simd_*` call;
* all match the real C scalar symbol to ~1 ULP (catches a mismapped name);
* all match `Base` within a few ULP (catches e.g. a swapped `atan2` arg order);
* mutation-tested — deleting the `@llvm.compiler.used` line makes exactly the
  vectorisation assertions fail while the numeric ones still pass, confirming the
  assertion catches the real silent-fallback regression;
* survives package precompilation;
* Aqua and the existing suite still pass.

`InteractiveUtils` is added as a test dep for `code_native`.

## Caveats

* Benchmarks are arm64 (Apple Silicon) only — the speedup numbers above have not
  been reproduced on x86_64. *Correctness* on x86_64 is covered: CI's
  `macOS-15-intel / x64` job runs the full suite green, including the assertions that
  each mapping really emits its `_simd_*` call, so the 4-lane/2-lane widths are right
  there too.
* The VFABI mangling is an LLVM-internal-ish interface. It's stable in practice
  (clang emits exactly these strings), but a future LLVM could change it — the
  emitted-code test is what would catch that.
